### PR TITLE
Logging stack traces on failed imports

### DIFF
--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -133,7 +133,7 @@ final class ApiSdkCommand extends Command
                     $this->task($task, $normalized);
                 }
             } catch (Throwable $e) {
-                $logger->alert("Error on a ".get_class($item), ['exception' => $e]);
+                $logger->alert('Error on a '.get_class($item), ['exception' => $e]);
                 continue;
             }
         }

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -132,7 +132,7 @@ final class ApiSdkCommand extends Command
                     $normalized = $this->serializer->serialize($item, 'json');
                     $this->task($task, $normalized);
                 }
-            } catch ($e) {
+            } catch (Throwable $e) {
                 $logger->alert("Error on a ".get_class($item), ['exception' => $e]);
                 continue;
             }

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -132,11 +132,8 @@ final class ApiSdkCommand extends Command
                     $normalized = $this->serializer->serialize($item, 'json');
                     $this->task($task, $normalized);
                 }
-            } catch (Throwable $e) {
-                $logger->alert($e->getMessage());
-                continue;
-            } catch (Error $e) {
-                $logger->error($e->getMessage());
+            } catch ($e) {
+                $logger->alert("Error on a ".get_class($item), ['exception' => $e]);
                 continue;
             }
         }

--- a/src/Search/Queue/BasicTransformer.php
+++ b/src/Search/Queue/BasicTransformer.php
@@ -45,7 +45,7 @@ trait BasicTransformer
                 break;
 
             default:
-                throw new LogicException('ApiSDK does not exist for that type.');
+                throw new LogicException("ApiSDK does not exist for the type `{$item->getType()}`.");
         }
     }
 

--- a/src/Search/Workflow/CliLogger.php
+++ b/src/Search/Workflow/CliLogger.php
@@ -68,7 +68,7 @@ final class CliLogger implements LoggerInterface
         if (array_key_exists('exception', $context)) {
             $e = $context['exception'];
             $this->output->writeln($e->getMessage());
-            $this->output->writeln($e->getFile().':'$e->getLine());
+            $this->output->writeln($e->getFile().':'.$e->getLine());
             $this->output->writeln($e->getTraceAsString());
         }
     }

--- a/src/Search/Workflow/CliLogger.php
+++ b/src/Search/Workflow/CliLogger.php
@@ -25,6 +25,7 @@ final class CliLogger implements LoggerInterface
     public function alert($message, array $context = array())
     {
         $this->output->writeln('<error>ALERT: '.$message.'</error>');
+        $this->dumpExceptionIfPresent($context);
     }
 
     public function critical($message, array $context = array())
@@ -60,5 +61,15 @@ final class CliLogger implements LoggerInterface
     public function log($level, $message, array $context = array())
     {
         $this->output->writeln($message);
+    }
+
+    private function dumpExceptionIfPresent(array $context)
+    {
+        if (array_key_exists('exception', $context)) {
+            $e = $context['exception'];
+            $this->output->writeln($e->getMessage());
+            $this->output->writeln($e->getFile().':'$e->getLine());
+            $this->output->writeln($e->getTraceAsString());
+        }
     }
 }


### PR DESCRIPTION
This should really use Monolog, so that we can send the logs also to files and format them appropriately, etc.

This is the minimal change to be able to debug what is happening in the end2end environment.

Unfortunately there seem to be no generic way of dumping the identifier for a Model object from the SDK, so I can't put a `getId()` in the message as some Models do not have it.