### PR TITLE
Umask must make files group-writable

### DIFF
--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -65,7 +65,7 @@ final class Kernel implements MinimalKernel
     public function __construct($config = [])
     {
         // perms.
-        umask(022);
+        umask(002);
         $app = new Application();
         // Load config
         $app['config'] = array_merge([


### PR DESCRIPTION
So that www-data and elife can delete and rewrite files from one another. This will also require all files to be created in the www-data group