### PR TITLE
Appropriate level for continuously printed statements

### DIFF
--- a/src/Search/Gearman/Command/QueueCommand.php
+++ b/src/Search/Gearman/Command/QueueCommand.php
@@ -130,7 +130,7 @@ class QueueCommand extends Command
     {
         $logger->debug('Loop start... [');
         $timeout = $input->getOption('queue-timeout');
-        $logger->info('-> Listening to topic ', ['topic' => $this->topic]);
+        $logger->debug('-> Listening to topic ', ['topic' => $this->topic]);
         if ($this->queue->isValid()) {
             $item = $this->queue->dequeue($timeout);
             // Transform into something for gearman.
@@ -153,7 +153,7 @@ class QueueCommand extends Command
                 'id' => $item->getId(),
             ]);
         } else {
-            $logger->info('-> Queue is empty ', ['topic' => $this->topic]);
+            $logger->debug('-> Queue is empty ', ['topic' => $this->topic]);
         }
         $logger->debug("]\n");
 


### PR DESCRIPTION
These logs are written every few seconds even if the queue is empty, best to leave them at `debug` level so that we can filter out when things are positively happening at with the `info` level.