### PR TITLE
Skipping nulls representing invalid articles

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -553,7 +553,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/6b9e8fda78dfd21aa0208c0137c83e87adad2f38",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/b3b1321",
                 "reference": "b3b1321",
                 "shasum": ""
             },
@@ -632,7 +632,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/ea6d0d19cb28753731d68f7ed370a997792a0225",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/ea6d0d1",
                 "reference": "ea6d0d1",
                 "shasum": ""
             },
@@ -680,7 +680,7 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-validator-php/zipball/6dc70d71f5212588c3851b3b26e50474839bcffd",
+                "url": "https://api.github.com/repos/elifesciences/api-validator-php/zipball/6dc70d7",
                 "reference": "6dc70d7",
                 "shasum": ""
             },

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -97,7 +97,7 @@ final class ApiSdkCommand extends Command
     {
         $logger->info('Importing Research Articles');
         $events = $this->sdk->articles();
-        $this->iterateSerializeTask($events, $logger, 'research_article_validate', $events->count());
+        $this->iterateSerializeTask($events, $logger, 'research_article_validate', $events->count(), $skipInvalid = true);
     }
 
     public function importInterviews(LoggerInterface $logger)
@@ -121,11 +121,14 @@ final class ApiSdkCommand extends Command
         $this->iterateSerializeTask($articles, $logger, 'blog_article_validate', $articles->count());
     }
 
-    private function iterateSerializeTask(Traversable $items, LoggerInterface $logger, string $task, int $count = 0)
+    private function iterateSerializeTask(Traversable $items, LoggerInterface $logger, string $task, int $count = 0, $skipInvalid = false)
     {
         $progress = new ProgressBar($this->output, $count);
         foreach ($items as $item) {
             $progress->advance();
+            if ($item === null) {
+                continue;
+            }
             try {
                 $normalized = $this->serializer->serialize($item, 'json');
                 $this->task($task, $normalized);


### PR DESCRIPTION
Temporary hack to allow imports without a fully valid article corpus