### PR TITLE
Performing ci-import explicitly in CI build

### DIFF
--- a/project_tests.sh
+++ b/project_tests.sh
@@ -4,3 +4,4 @@ set -e
 rm -f build/*.xml
 proofreader src/ tests/ web/
 vendor/bin/phpunit --log-junit build/phpunit.xml
+bin/ci-import ci


### PR DESCRIPTION
Will avoid doing this in the formula, so that we can customize the order and perform deploy+tests+import in this order, not (deploy and import)+tests