### PR TITLE
gearman:worker should not hang on work()

### DIFF
--- a/bin/ci-import
+++ b/bin/ci-import
@@ -14,10 +14,10 @@ trap 'kill -INT -$waitingPid' INT
 sleep 5
 
 echo "Starting a gearman:worker"
-./bin/console gearman:worker --env="$environment" 2>&1 | tee /tmp/gearman-worker.log &
+./bin/console gearman:worker --env="$environment" >> /tmp/gearman-worker.log 2>&1 &
 workerPid=$!
 echo "Starting a queue:watch"
-./bin/console queue:watch --env="$environment" 2>&1 | tee /tmp/queue-watch.log &
+./bin/console queue:watch --env="$environment" >> /tmp/queue-watch.log 2>&1 &
 queueWatchPid=$!
 echo "Starting import"
 ./bin/console queue:import all --env="$environment"

--- a/bin/ci-import
+++ b/bin/ci-import
@@ -16,11 +16,15 @@ sleep 5
 echo "Starting a gearman:worker"
 ./bin/console gearman:worker --env="$environment" >> /tmp/gearman-worker.log 2>&1 &
 workerPid=$!
+echo "gearman:worker PID $workerPid"
 echo "Starting a queue:watch"
 ./bin/console queue:watch --env="$environment" >> /tmp/queue-watch.log 2>&1 &
 queueWatchPid=$!
+echo "queue:watch PID $queueWatchPid"
+
 echo "Starting import"
 ./bin/console queue:import all --env="$environment"
+echo "Finished launching import"
 
 # will return also on failing conditions such as dead processes
 timeout 60 ./bin/wait-for-empty-gearman-queue "$environment" &

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -159,8 +159,9 @@ final class ApiSdkCommand extends Command
 
     private function enqueue($type, $identifier)
     {
+        $this->logger->info("Item ($type, $identifier) being enqueued");
         $item = new InternalSqsMessage($type, $identifier);
         $this->queue->enqueue($item);
-        $this->logger->info("Item ($type, $identifier) added successfully");
+        $this->logger->info("Item ($type, $identifier) enqueued successfully");
     }
 }

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -137,7 +137,7 @@ final class ApiSdkCommand extends Command
         $limit = $this->limit;
 
         $items->rewind();
-        while ($items->valid() && $limit()) {
+        while ($items->valid() && !$limit()) {
             $progress->advance();
             try {
                 $item = $items->current();

--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -132,6 +132,7 @@ final class ApiSdkCommand extends Command
 
     private function iterateSerializeTask(Iterator $items, string $type, $method = 'getId', int $count = 0, $skipInvalid = false)
     {
+        $this->logger->info("Importing $count items of type $type");
         $progress = new ProgressBar($this->output, $count);
         $limit = $this->limit;
 

--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -88,6 +88,7 @@ final class Kernel implements MinimalKernel
             'elastic_index' => 'elife_search',
             'file_log_path' => self::ROOT.'/var/logs/all.log',
             'file_error_log_path' => self::ROOT.'/var/logs/error.log',
+            'gearman_worker_timeout' => 20000,
             'process_memory_limit' => 256,
             'aws' => array_merge([
                 'credential_file' => false,
@@ -313,6 +314,7 @@ final class Kernel implements MinimalKernel
                 } catch (Throwable $e) {
                 }
             }
+            $worker->setTimeout($app['config']['gearman_worker_timeout']);
 
             return $worker;
         };

--- a/src/Search/Limit/LoggingMiddleware.php
+++ b/src/Search/Limit/LoggingMiddleware.php
@@ -23,7 +23,7 @@ class LoggingMiddleware implements Limit
         if ($limitReached) {
             $this->reasons = $limit->getReasons();
             foreach ($this->reasons as $reason) {
-                $this->logger->error($reason);
+                $this->logger->info($reason);
             }
         }
 

--- a/src/Search/Queue/Mock/WatchableQueueMock.php
+++ b/src/Search/Queue/Mock/WatchableQueueMock.php
@@ -20,11 +20,9 @@ final class WatchableQueueMock implements WatchableQueue
      *
      * Mock: Add item to queue.
      */
-    public function enqueue(QueueItem $item) : bool
+    public function enqueue(QueueItem $item)
     {
         array_push($this->items, $item);
-
-        return true;
     }
 
     /**

--- a/src/Search/Queue/SqsWatchableQueue.php
+++ b/src/Search/Queue/SqsWatchableQueue.php
@@ -21,21 +21,15 @@ final class SqsWatchableQueue implements WatchableQueue
     /**
      * Adds item to the queue.
      */
-    public function enqueue(QueueItem $item) : bool
+    public function enqueue(QueueItem $item)
     {
-        try {
-            $this->client->sendMessage([
-                'QueueUrl' => $this->url,
-                'MessageBody' => json_encode([
-                    'type' => $item->getType(),
-                    'id' => $item->getId(),
-                ]),
-            ]);
-        } catch (Throwable $e) {
-            return false;
-        }
-
-        return true;
+        $this->client->sendMessage([
+            'QueueUrl' => $this->url,
+            'MessageBody' => json_encode([
+                'type' => $item->getType(),
+                'id' => $item->getId(),
+            ]),
+        ]);
     }
 
     /**

--- a/src/Search/Queue/WatchableQueue.php
+++ b/src/Search/Queue/WatchableQueue.php
@@ -9,7 +9,7 @@ interface WatchableQueue extends Countable
     /**
      * Adds item to the queue.
      */
-    public function enqueue(QueueItem $item) : bool;
+    public function enqueue(QueueItem $item);
 
     /**
      * Gets an item to process.

--- a/tests/src/Search/Gearman/GearmanTaskDriverTest.php
+++ b/tests/src/Search/Gearman/GearmanTaskDriverTest.php
@@ -108,8 +108,8 @@ namespace tests\eLife\Search\Gearman {
 
             $this->assertEquals(
                 [
-                    'Worker started.',
-                    'Worker stopped because of limits reached.',
+                    'gearman:worker: Started listening.',
+                    'gearman:worker: Stopped because of limits reached.',
                 ],
                 $this->logLines
             );


### PR DESCRIPTION
Like for queue:watch, it should wait for a finite amount and then loop to check for signals or other limits. The default behavior seem to be an infinite timeout.