### PR TITLE
Dead code: release() method

### DIFF
--- a/src/Search/Queue/Mock/WatchableQueueMock.php
+++ b/src/Search/Queue/Mock/WatchableQueueMock.php
@@ -43,16 +43,6 @@ final class WatchableQueueMock implements WatchableQueue
         unset($this->process[$item->getReceipt()]);
     }
 
-    /**
-     * Mock: re-add to queue.
-     */
-    public function release(QueueItem $item) : bool
-    {
-        array_unshift($this->items, $item);
-
-        return true;
-    }
-
     public function clean()
     {
         $this->items = [];

--- a/src/Search/Queue/SqsWatchableQueue.php
+++ b/src/Search/Queue/SqsWatchableQueue.php
@@ -3,7 +3,6 @@
 namespace eLife\Search\Queue;
 
 use Aws\Sqs\SqsClient;
-use Throwable;
 
 final class SqsWatchableQueue implements WatchableQueue
 {
@@ -60,24 +59,6 @@ final class SqsWatchableQueue implements WatchableQueue
             'QueueUrl' => $this->url,
             'ReceiptHandle' => $item->getReceipt(),
         ]);
-    }
-
-    /**
-     * This will happen when an error happens, we release the item back into the queue.
-     */
-    public function release(QueueItem $item) : bool
-    {
-        try {
-            $this->client->changeMessageVisibility([
-                'QueueUrl' => $this->url,
-                'ReceiptHandle' => $item->getReceipt(),
-                'VisibilityTimeout' => 0,
-            ]);
-        } catch (Throwable $e) {
-            return false;
-        }
-
-        return true;
     }
 
     public function clean()

--- a/src/Search/Queue/WatchableQueue.php
+++ b/src/Search/Queue/WatchableQueue.php
@@ -24,11 +24,6 @@ interface WatchableQueue extends Countable
     public function commit(QueueItem $item);
 
     /**
-     * This will happen when an error happens, we release the item back into the queue.
-     */
-    public function release(QueueItem $item) : bool;
-
-    /**
      * Deletes everything from the queue.
      */
     public function clean();

--- a/tests/src/Search/ExampleWebTest.php
+++ b/tests/src/Search/ExampleWebTest.php
@@ -12,11 +12,8 @@ class ExampleWebTest extends ElasticTestCase
      */
     public function testCanRunCommand()
     {
-        // Run command
-        $lines = $this->runCommand('hello');
-        // And test.
-        $this->assertEquals('Hello from the outside (of the global scope)', $lines[0]);
-        $this->assertEquals('This is working', $lines[1]);
+        $logs = $this->runCommand('help');
+        $this->assertEquals(0, count($logs));
     }
 
     /**


### PR DESCRIPTION
This is not used at the moment, and in general we have started to log errors and remove the message from the queue rather than letting it there for a possibly infinite number of retries