### PR TITLE
Adding a boatload of logs to find out the race condition in queue:watch

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -574,12 +574,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-client-php.git",
-                "reference": "54046974d33c56f6276df7d757fa39c4ed9de9d9"
+                "reference": "21724189d4806557cceb229ebbfec142732408cb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-client-php/zipball/54046974d33c56f6276df7d757fa39c4ed9de9d9",
-                "reference": "54046974d33c56f6276df7d757fa39c4ed9de9d9",
+                "url": "https://api.github.com/repos/elifesciences/api-client-php/zipball/21724189d4806557cceb229ebbfec142732408cb",
+                "reference": "21724189d4806557cceb229ebbfec142732408cb",
                 "shasum": ""
             },
             "require": {
@@ -621,7 +621,7 @@
                 "GPL-3.0+"
             ],
             "description": "eLife Sciences API client",
-            "time": "2016-12-16 15:16:20"
+            "time": "2017-01-10 15:17:00"
         },
         {
             "name": "elife/api-sdk",

--- a/config/end2end.php
+++ b/config/end2end.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'debug' => true,
     'gearman_servers' => ['localhost'],
     'api_url' => 'http://end2end--gateway.elifesciences.org/',
     'api_requests_batch' => 20,

--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Cache\FilesystemCache;
 use Elasticsearch\ClientBuilder;
 use eLife\ApiClient\HttpClient\BatchingHttpClient;
 use eLife\ApiClient\HttpClient\Guzzle6HttpClient;
+use eLife\ApiClient\HttpClient\NotifyingHttpClient;
 use eLife\ApiSdk\ApiSdk;
 use eLife\ApiValidator\MessageValidator\JsonMessageValidator;
 use eLife\ApiValidator\SchemaFinder\PuliSchemaFinder;
@@ -39,6 +40,7 @@ use GearmanClient;
 use GearmanWorker;
 use GuzzleHttp\Client;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use JMS\Serializer\EventDispatcher\EventDispatcher;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerBuilder;
@@ -220,6 +222,16 @@ final class Kernel implements MinimalKernel
         $app['guzzle'] = function (Application $app) {
             // Create default HandlerStack
             $stack = HandlerStack::create();
+            $logger = $app['logger'];
+            if ($app['config']['debug']) {
+                $stack->push(
+                    Middleware::mapRequest(function ($request) use ($logger) {
+                        $logger->debug("Request performed in Guzzle Middleware: {$request->getUri()}");
+
+                        return $request;
+                    })
+                );
+            }
             $stack->push(
                 new CacheMiddleware(
                     new PublicCacheStrategy(
@@ -238,7 +250,7 @@ final class Kernel implements MinimalKernel
         };
 
         $app['api.sdk'] = function (Application $app) {
-            return new ApiSdk(
+            $notifyingHttpClient = new NotifyingHttpClient(
                 new BatchingHttpClient(
                     new Guzzle6HttpClient(
                         $app['guzzle']
@@ -246,6 +258,14 @@ final class Kernel implements MinimalKernel
                     $app['config']['api_requests_batch']
                 )
             );
+            if ($app['config']['debug']) {
+                $logger = $app['logger'];
+                $notifyingHttpClient->addRequestListener(function ($request) use ($logger) {
+                    $logger->debug("Request performed in NotifyingHttpClient: {$request->getUri()}");
+                });
+            }
+
+            return new ApiSdk($notifyingHttpClient);
         };
 
         $app['api.subjects'] = function (Application $app) {


### PR DESCRIPTION
The test of indexing a new article is randomly failing, so these will help understand whether any 404 is reused with respect to making a new request to /articles/:id.