### PR TITLE
Limits are not a good exit reason for queue:import

### DIFF
--- a/src/Search/Gearman/Command/ApiSdkCommand.php
+++ b/src/Search/Gearman/Command/ApiSdkCommand.php
@@ -8,6 +8,7 @@ use eLife\Search\Queue\InternalSqsMessage;
 use eLife\Search\Queue\WatchableQueue;
 use Iterator;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
@@ -137,7 +138,10 @@ final class ApiSdkCommand extends Command
         $limit = $this->limit;
 
         $items->rewind();
-        while ($items->valid() && !$limit()) {
+        while ($items->valid()) {
+            if ($limit()) {
+                throw new RuntimeException('Command cannot complete because: '.implode(', ', $limit->getReasons()));
+            }
             $progress->advance();
             try {
                 $item = $items->current();


### PR DESCRIPTION
While gearman:worker and queue:watch are long-running processes that
will be respawn immediately by Upstart when running out of memory, this
is an interactive process. Therefore if it runs out of memory it leaves
the import in an incomplete state, and should exit without success.