### PR TITLE
ELPP-2160 Order of content on homepage

### DIFF
--- a/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
@@ -23,15 +23,24 @@ _default_:
     title:
       type: string
 
+    # The actual sort date
+    sortDate:
+      type: date
+      format: strict_date_optional_time
+      index: not_analyzed
+
     # Dates to sort on all fields.
     published:
       type: date
-      format: strict_date_optional_time||epoch_millis
+      format: strict_date_optional_time
+      index: not_analyzed
 
     updated:
       type: date
-      format: strict_date_optional_time||epoch_millis
+      format: strict_date_optional_time
+      index: not_analyzed
 
     statusDate:
       type: date
-      format: strict_date_optional_time||epoch_millis
+      format: strict_date_optional_time
+      index: not_analyzed

--- a/src/Search/Api/Elasticsearch/Command/resources/article.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/article.yaml
@@ -270,4 +270,3 @@ article:
           type: string
         value:
           type: string
-#  date_detection: true

--- a/src/Search/Api/Elasticsearch/Command/resources/article.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/article.yaml
@@ -6,8 +6,6 @@ article:
       type: string
     doi:
       type: string
-    type:
-      type: string
     copyright:
       type: object
       properties:
@@ -272,4 +270,4 @@ article:
           type: string
         value:
           type: string
-  date_detection: true
+#  date_detection: true

--- a/src/Search/Api/Elasticsearch/Command/resources/blog-article.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/blog-article.yaml
@@ -12,8 +12,6 @@ blog-article:
           type: string
         title:
           type: string
-        type:
-          type: string
         uri:
           type: string
         width:

--- a/src/Search/Api/Elasticsearch/Command/resources/event.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/event.yaml
@@ -18,9 +18,6 @@ event:
       format: strict_date_optional_time||epoch_millis
     timezone:
       type: string
-    type:
-      type: string
-      index: not_analyzed
     venue:
       properties:
         address:

--- a/src/Search/Api/Elasticsearch/Command/resources/interview.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/interview.yaml
@@ -32,6 +32,3 @@ interview:
               type: string
             preferred:
               type: string
-    type:
-      type: string
-      index: not_analyzed

--- a/src/Search/Api/Elasticsearch/Command/resources/labs-experiment.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/labs-experiment.yaml
@@ -66,6 +66,3 @@ labs-experiment:
       type: string
     number:
       type: long
-    type:
-      type: string
-      index: not_analyzed

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -140,9 +140,6 @@ final class ElasticQueryBuilder implements QueryBuilder
 
     public function getQuery(): QueryExecutor
     {
-        //        echo "<pre>";
-//        var_dump(json_encode($this->query, JSON_PRETTY_PRINT));
-//        exit;
         $exec = clone $this->exec;
         $exec->setQuery($this);
 

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -106,19 +106,7 @@ final class ElasticQueryBuilder implements QueryBuilder
     public function sortByDate($reverse = false): QueryBuilder
     {
         $this->sort([
-            'statusDate' => [
-                'order' => $this->getSort($reverse),
-                'missing' => '_last',
-            ],
-        ]);
-        $this->sort([
-            'published' => [
-                'order' => $this->getSort($reverse),
-                'missing' => '_last',
-            ],
-        ]);
-        $this->sort([
-            'updated' => [
+            'sortDate' => [
                 'order' => $this->getSort($reverse),
                 'missing' => '_last',
             ],
@@ -152,6 +140,9 @@ final class ElasticQueryBuilder implements QueryBuilder
 
     public function getQuery(): QueryExecutor
     {
+        //        echo "<pre>";
+//        var_dump(json_encode($this->query, JSON_PRETTY_PRINT));
+//        exit;
         $exec = clone $this->exec;
         $exec->setQuery($this);
 

--- a/src/Search/Api/Response/ImageBannerResponse.php
+++ b/src/Search/Api/Response/ImageBannerResponse.php
@@ -34,7 +34,7 @@ final class ImageBannerResponse implements ImageVariant
         $sizes = [];
         foreach ($urls as $url) {
             foreach ($url as $k => $size) {
-                $sizes[$k] = str_replace(['http:/', 'internal_elife_dummy_api'], ['https:/', 'internal_elife_dummy_api.com'], $size);
+                $sizes[$k] = str_replace(['http:/', 'internal_elife_dummy_api'], ['https:/', 'internalelifedummyapi.com'], $size);
             }
         }
 

--- a/src/Search/Api/Response/ImageThumbnailResponse.php
+++ b/src/Search/Api/Response/ImageThumbnailResponse.php
@@ -34,7 +34,7 @@ final class ImageThumbnailResponse implements ImageVariant
         $sizes = [];
         foreach ($urls as $url) {
             foreach ($url as $k => $size) {
-                $sizes[$k] = str_replace(['http:/', 'internal_elife_dummy_api'], ['https:/', 'internal_elife_dummy_api.com'], $size);
+                $sizes[$k] = str_replace(['http:/', 'internal_elife_dummy_api'], ['https:/', 'internalelifedummyapi.site.com'], $size);
             }
         }
 

--- a/src/Search/Workflow/BlogArticleWorkflow.php
+++ b/src/Search/Workflow/BlogArticleWorkflow.php
@@ -20,6 +20,7 @@ final class BlogArticleWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -84,8 +85,7 @@ final class BlogArticleWorkflow implements Workflow
         $this->logger->debug('BlogArticle<'.$blogArticle->getId().'> Indexing '.$blogArticle->getTitle());
         // Normalized fields.
         $blogArticleObject = json_decode($this->serialize($blogArticle));
-        $sortDate = $blogArticle->getPublishedDate();
-        $blogArticleObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        $this->addSortDate($blogArticleObject, $blogArticle->getPublishedDate());
 
         // Return.
         return [

--- a/src/Search/Workflow/BlogArticleWorkflow.php
+++ b/src/Search/Workflow/BlogArticleWorkflow.php
@@ -81,11 +81,15 @@ final class BlogArticleWorkflow implements Workflow
      */
     public function index(BlogArticle $blogArticle) : array
     {
-        // This step is still not used very much.
         $this->logger->debug('BlogArticle<'.$blogArticle->getId().'> Indexing '.$blogArticle->getTitle());
+        // Normalized fields.
+        $blogArticleObject = json_decode($this->serialize($blogArticle));
+        $sortDate = $blogArticle->getPublishedDate();
+        $blogArticleObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+
         // Return.
         return [
-            'json' => $this->serialize($blogArticle),
+            'json' => json_encode($blogArticleObject),
             'type' => 'blog-article',
             'id' => $blogArticle->getId(),
         ];

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -20,6 +20,7 @@ final class CollectionWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -84,8 +85,7 @@ final class CollectionWorkflow implements Workflow
         $this->logger->debug('Collection<'.$collection->getId().'> Indexing '.$collection->getTitle());
         // Normalized fields.
         $collectionObject = json_decode($this->serialize($collection));
-        $sortDate = $collection->getPublishedDate();
-        $collectionObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        $this->addSortDate($collectionObject, $collection->getPublishedDate());
         // Return.
         return [
             'json' => json_encode($collectionObject),

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -13,7 +13,6 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
-use function GuzzleHttp\json_encode;
 
 final class CollectionWorkflow implements Workflow
 {

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -13,6 +13,7 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
+use function GuzzleHttp\json_encode;
 
 final class CollectionWorkflow implements Workflow
 {
@@ -81,11 +82,14 @@ final class CollectionWorkflow implements Workflow
      */
     public function index(Collection $collection) : array
     {
-        // This step is still not used very much.
         $this->logger->debug('Collection<'.$collection->getId().'> Indexing '.$collection->getTitle());
+        // Normalized fields.
+        $collectionObject = json_decode($this->serialize($collection));
+        $sortDate = $collection->getPublishedDate();
+        $collectionObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
         // Return.
         return [
-            'json' => $this->serialize($collection),
+            'json' => json_encode($collectionObject),
             'type' => 'collection',
             'id' => $collection->getId(),
         ];

--- a/src/Search/Workflow/EventWorkflow.php
+++ b/src/Search/Workflow/EventWorkflow.php
@@ -13,6 +13,7 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
+use function GuzzleHttp\json_encode;
 
 final class EventWorkflow implements Workflow
 {
@@ -85,8 +86,13 @@ final class EventWorkflow implements Workflow
     {
         $this->logger->debug('Event<'.$event->getId().'> indexing with title '.$event->getTitle());
 
+        // Normalized fields.
+        $eventObject = json_decode($this->serialize($event));
+        $sortDate = $event->getStarts();
+        $eventObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+
         return [
-            'json' => $this->serialize($event),
+            'json' => json_encode($eventObject),
             'type' => 'event',
             'id' => $event->getId(),
         ];

--- a/src/Search/Workflow/EventWorkflow.php
+++ b/src/Search/Workflow/EventWorkflow.php
@@ -17,6 +17,7 @@ use Throwable;
 final class EventWorkflow implements Workflow
 {
     use JsonSerializeTransport;
+    use SortDate;
 
     const WORKFLOW_SUCCESS = 1;
     const WORKFLOW_FAILURE = -1;
@@ -87,8 +88,8 @@ final class EventWorkflow implements Workflow
 
         // Normalized fields.
         $eventObject = json_decode($this->serialize($event));
-        $sortDate = $event->getStarts();
-        $eventObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        // Adds the start time of the event to sort on.
+        $this->addSortDate($eventObject, $event->getStarts());
 
         return [
             'json' => json_encode($eventObject),

--- a/src/Search/Workflow/EventWorkflow.php
+++ b/src/Search/Workflow/EventWorkflow.php
@@ -13,7 +13,6 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
-use function GuzzleHttp\json_encode;
 
 final class EventWorkflow implements Workflow
 {

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -13,6 +13,7 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
+use function GuzzleHttp\json_encode;
 
 final class InterviewWorkflow implements Workflow
 {
@@ -80,11 +81,15 @@ final class InterviewWorkflow implements Workflow
      */
     public function index(Interview $interview) : array
     {
-        // This step is still not used very much.
         $this->logger->debug('Interview<'.$interview->getId().'> Indexing '.$interview->getTitle());
 
+        // Normalized fields.
+        $interviewObject = json_decode($this->serialize($interview));
+        $sortDate = $interview->getPublishedDate();
+        $interviewObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+
         return [
-            'json' => $this->serialize($interview),
+            'json' => json_encode($interviewObject),
             'type' => 'interview',
             'id' => $interview->getId(),
         ];

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -13,7 +13,6 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
-use function GuzzleHttp\json_encode;
 
 final class InterviewWorkflow implements Workflow
 {

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -20,6 +20,7 @@ final class InterviewWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -84,8 +85,8 @@ final class InterviewWorkflow implements Workflow
 
         // Normalized fields.
         $interviewObject = json_decode($this->serialize($interview));
-        $sortDate = $interview->getPublishedDate();
-        $interviewObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        // Add publish date to sort on.
+        $this->addSortDate($interviewObject, $interview->getPublishedDate());
 
         return [
             'json' => json_encode($interviewObject),

--- a/src/Search/Workflow/LabsExperimentWorkflow.php
+++ b/src/Search/Workflow/LabsExperimentWorkflow.php
@@ -20,6 +20,7 @@ final class LabsExperimentWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -84,8 +85,7 @@ final class LabsExperimentWorkflow implements Workflow
 
         // Normalized fields.
         $labsExperimentObject = json_decode($this->serialize($labsExperiment));
-        $sortDate = $labsExperiment->getPublishedDate();
-        $labsExperimentObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        $this->addSortDate($labsExperimentObject, $labsExperiment->getPublishedDate());
 
         return [
             'json' => json_encode($labsExperimentObject),

--- a/src/Search/Workflow/LabsExperimentWorkflow.php
+++ b/src/Search/Workflow/LabsExperimentWorkflow.php
@@ -13,6 +13,7 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
+use function GuzzleHttp\json_encode;
 
 final class LabsExperimentWorkflow implements Workflow
 {
@@ -80,11 +81,15 @@ final class LabsExperimentWorkflow implements Workflow
      */
     public function index(LabsExperiment $labsExperiment) : array
     {
-        // This step is still not used very much.
         $this->logger->debug('LabsExperiment<'.$labsExperiment->getNumber().'> Indexing '.$labsExperiment->getTitle());
 
+        // Normalized fields.
+        $labsExperimentObject = json_decode($this->serialize($labsExperiment));
+        $sortDate = $labsExperiment->getPublishedDate();
+        $labsExperimentObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+
         return [
-            'json' => $this->serialize($labsExperiment),
+            'json' => json_encode($labsExperimentObject),
             'type' => 'labs-experiment',
             'id' => $labsExperiment->getNumber(),
         ];

--- a/src/Search/Workflow/LabsExperimentWorkflow.php
+++ b/src/Search/Workflow/LabsExperimentWorkflow.php
@@ -13,7 +13,6 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
-use function GuzzleHttp\json_encode;
 
 final class LabsExperimentWorkflow implements Workflow
 {

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -13,6 +13,7 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
+use function GuzzleHttp\json_encode;
 
 final class PodcastEpisodeWorkflow implements Workflow
 {
@@ -82,8 +83,13 @@ final class PodcastEpisodeWorkflow implements Workflow
     {
         $this->logger->debug('indexing '.$podcastEpisode->getTitle());
 
+        // Normalized fields.
+        $podcastEpisodeObject = json_decode($this->serialize($podcastEpisode));
+        $sortDate = $podcastEpisode->getPublishedDate();
+        $podcastEpisodeObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+
         return [
-            'json' => $this->serialize($podcastEpisode),
+            'json' => json_encode($podcastEpisode),
             'type' => 'podcast-episode',
             'id' => $podcastEpisode->getNumber(),
         ];

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -20,6 +20,7 @@ final class PodcastEpisodeWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -84,8 +85,8 @@ final class PodcastEpisodeWorkflow implements Workflow
 
         // Normalized fields.
         $podcastEpisodeObject = json_decode($this->serialize($podcastEpisode));
-        $sortDate = $podcastEpisode->getPublishedDate();
-        $podcastEpisodeObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        // Add sort date.
+        $this->addSortDate($podcastEpisodeObject, $podcastEpisode->getPublishedDate());
 
         return [
             'json' => json_encode($podcastEpisode),

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -89,7 +89,7 @@ final class PodcastEpisodeWorkflow implements Workflow
         $this->addSortDate($podcastEpisodeObject, $podcastEpisode->getPublishedDate());
 
         return [
-            'json' => json_encode($podcastEpisode),
+            'json' => json_encode($podcastEpisodeObject),
             'type' => 'podcast-episode',
             'id' => $podcastEpisode->getNumber(),
         ];
@@ -134,6 +134,7 @@ final class PodcastEpisodeWorkflow implements Workflow
         } catch (Throwable $e) {
             $this->logger->error('PodcastEpisode<'.$id.'> rolling back', [
                 'exception' => $e,
+                'document' => $result ?? null,
             ]);
             $this->client->deleteDocument($type, $id);
             // We failed.

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -13,7 +13,6 @@ use eLife\Search\Gearman\InvalidWorkflow;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Serializer\Serializer;
 use Throwable;
-use function GuzzleHttp\json_encode;
 
 final class PodcastEpisodeWorkflow implements Workflow
 {

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -144,7 +144,7 @@ final class ResearchArticleWorkflow implements Workflow
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
 
-        $sortDate = $article->getPublishedDate() ? $article->getPublishedDate() : $article->getStatusDate();
+        $sortDate = $article->getStatusDate() ? $article->getStatusDate() : $article->getPublishedDate();
         $articleObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
 
         $this->logger->debug('Article<'.$article->getId().'> Detected type '.($article->getType() ?? 'research-article'));

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -23,6 +23,7 @@ final class ResearchArticleWorkflow implements Workflow
     const WORKFLOW_FAILURE = -1;
 
     use JsonSerializeTransport;
+    use SortDate;
 
     /**
      * @var Serializer
@@ -145,7 +146,7 @@ final class ResearchArticleWorkflow implements Workflow
         ];
 
         $sortDate = $article->getStatusDate() ? $article->getStatusDate() : $article->getPublishedDate();
-        $articleObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
+        $this->addSortDate($articleObject, $sortDate);
 
         $this->logger->debug('Article<'.$article->getId().'> Detected type '.($article->getType() ?? 'research-article'));
 

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -91,7 +91,6 @@ final class ResearchArticleWorkflow implements Workflow
      */
     public function index(ArticleVersion $article) : array
     {
-        // This step is still not used very much.
         $this->logger->debug('ResearchArticle<'.$article->getId().'> Indexing '.$article->getTitle());
 
         $articleObject = json_decode($this->serialize($article));
@@ -144,6 +143,9 @@ final class ResearchArticleWorkflow implements Workflow
             'format' => 'json',
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
+
+        $sortDate = $article->getPublishedDate() ? $article->getPublishedDate() : $article->getStatusDate();
+        $articleObject->sortDate = $sortDate->format('Y-m-d\TH:i:s\Z');
 
         $this->logger->debug('Article<'.$article->getId().'> Detected type '.($article->getType() ?? 'research-article'));
 

--- a/src/Search/Workflow/SortDate.php
+++ b/src/Search/Workflow/SortDate.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace eLife\Search\Workflow;
+
+use DateTimeImmutable;
+
+trait SortDate
+{
+    public function addSortDate($object, DateTimeImmutable $date = null)
+    {
+        if ($date) {
+            $object->sortDate = $date->format('Y-m-d\TH:i:s\Z');
+        }
+    }
+}

--- a/tests/src/Search/SortOrderTest.php
+++ b/tests/src/Search/SortOrderTest.php
@@ -32,6 +32,7 @@ class SortOrderTest extends ElasticTestCase
                     ],
                 'version' => 3,
                 'published' => '2016-11-18T00:00:00Z',
+                'sortDate' => '2016-11-18T00:00:00Z',
                 'statusDate' => '2016-12-05T16:36:45Z',
                 'pdf' => 'https://publishing-cdn.elifesciences.org/19662/elife-19662-v3.pdf',
                 'subjects' => [
@@ -62,6 +63,7 @@ class SortOrderTest extends ElasticTestCase
                         'Rat',
                     ],
                 'published' => '2016-12-19T00:00:00Z',
+                'sortDate' => '2016-12-19T00:00:00Z',
                 'statusDate' => '2016-12-19T00:00:00Z',
                 'pdf' => 'https://publishing-cdn.elifesciences.org/15275/elife-15275-v1.pdf',
                 'subjects' => [


### PR DESCRIPTION
@giorgiosironi @thewilkybarkid @elrossco22 

I've changed the way we are sorting to instead be a "virtual" property that we can choose at insert time what it is. This will increase performance at the cost of having to reindex if we decide to change which fields we use. There are 2 solutions I can see for solving this issue in the future:

- Robust solution for zero downtime migrations (reindex content into new index, switcheroo)
- Process for creating and applying migrations for changes to indexes

This does however solve the immediate issue.