### PR TITLE
Changed logging for elasticsearch (dev + CI)

### DIFF
--- a/config/ci.php
+++ b/config/ci.php
@@ -9,6 +9,7 @@ return [
     'ttl' => 0,
     'elastic_force_sync' => true,
     'gearman_servers' => ['localhost'],
+    'elastic_logging' => true,
     'gearman_auto_restart' => false,
     'aws' => [
         'queue_name' => 'search--ci',

--- a/config/dev.php
+++ b/config/dev.php
@@ -10,6 +10,7 @@ return [
     'gearman_servers' => ['localhost'],
     'gearman_auto_restart' => false,
     'elastic_force_sync' => true,
+    'elastic_logging' => true,
     'aws' => [
         'queue_name' => 'search--dev',
         'credential_file' => true,

--- a/config/local.example.php
+++ b/config/local.example.php
@@ -9,6 +9,7 @@ return [
     'api_url' => 'http://0.0.0.0:1234',
     'elastic_servers' => ['http://elife_search_elasticsearch:9200'],
     'annotation_cache' => false,
+    'elastic_logging' => true,
     'ttl' => 0,
     'file_log_path' => __DIR__.'../var/logs/all.log',
     'file_error_log_path' => __DIR__.'../var/logs/error.log',

--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -274,7 +274,7 @@ final class Kernel implements MinimalKernel
         };
 
         $app['default_controller'] = function (Application $app) {
-            return new SearchController($app['serializer'], $app['serializer.context'], $app['elastic.executor'], $app['cache'], $app['config']['api_url'], $app['config']['elastic_index']);
+            return new SearchController($app['serializer'], $app['logger'], $app['serializer.context'], $app['elastic.executor'], $app['cache'], $app['config']['api_url'], $app['config']['elastic_index']);
         };
 
         //#####################################################

--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -84,6 +84,7 @@ final class Kernel implements MinimalKernel
             'ttl' => 3600,
             'elastic_servers' => ['http://localhost:9200'],
             'elastic_index' => 'elife_search',
+            'elastic_logging' => false,
             'elastic_force_sync' => false,
             'file_logs_path' => self::ROOT.'/var/logs',
             'gearman_worker_timeout' => 20000,
@@ -289,7 +290,7 @@ final class Kernel implements MinimalKernel
             // Set hosts.
             $client->setHosts($app['config']['elastic_servers']);
             // Logging for ElasticSearch.
-            if ($app['config']['debug']) {
+            if ($app['config']['elastic_logging']) {
                 $client->setLogger($app['logger']);
             }
             $client->setSerializer($app['elastic.serializer']);


### PR DESCRIPTION
Comparing the application logs to the elasticsearch logs there is very little difference, elasticsearch seems to log an error, and then throw an exception. It includes a java stack trace (which we don't need!)

```
internal_elife_search_elasticsearch | MapperParsingException[failed to parse [sortDate]]; nested: IllegalArgumentException[unknown property [date]];
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:329)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.DocumentParser.parseObjectOrField(DocumentParser.java:311)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:328)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.DocumentParser.parseObject(DocumentParser.java:254)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.DocumentParser.parseDocument(DocumentParser.java:124)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.DocumentMapper.parse(DocumentMapper.java:309)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.shard.IndexShard.prepareIndex(IndexShard.java:584)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.shard.IndexShard.prepareIndexOnPrimary(IndexShard.java:563)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.index.TransportIndexAction.prepareIndexOperationOnPrimary(TransportIndexAction.java:211)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.index.TransportIndexAction.executeIndexRequestOnPrimary(TransportIndexAction.java:223)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.index.TransportIndexAction.shardOperationOnPrimary(TransportIndexAction.java:157)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.index.TransportIndexAction.shardOperationOnPrimary(TransportIndexAction.java:66)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryPhase.doRun(TransportReplicationAction.java:657)
internal_elife_search_elasticsearch | 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryOperationTransportHandler.messageReceived(TransportReplicationAction.java:287)
internal_elife_search_elasticsearch | 	at org.elasticsearch.action.support.replication.TransportReplicationAction$PrimaryOperationTransportHandler.messageReceived(TransportReplicationAction.java:279)
internal_elife_search_elasticsearch | 	at org.elasticsearch.transport.RequestHandlerRegistry.processMessageReceived(RequestHandlerRegistry.java:77)
internal_elife_search_elasticsearch | 	at org.elasticsearch.transport.TransportService$4.doRun(TransportService.java:378)
internal_elife_search_elasticsearch | 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:37)
internal_elife_search_elasticsearch | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
internal_elife_search_elasticsearch | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
internal_elife_search_elasticsearch | 	at java.lang.Thread.run(Thread.java:745)
internal_elife_search_elasticsearch | Caused by: java.lang.IllegalArgumentException: unknown property [date]
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.core.DateFieldMapper.innerParseCreateField(DateFieldMapper.java:520)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.core.NumberFieldMapper.parseCreateField(NumberFieldMapper.java:241)
internal_elife_search_elasticsearch | 	at org.elasticsearch.index.mapper.FieldMapper.parse(FieldMapper.java:321)
internal_elife_search_elasticsearch | 	... 21 more
```

I've replaced run time errors with some logging to record the same information we get back from elastic search. 