### PR TITLE
ELPP-2093 Added datetime filter to search api

### DIFF
--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -155,7 +155,7 @@ final class ElasticQueryBuilder implements QueryBuilder
             'sortDate' => [
                 'gte' => $fromDate->format('Y/m/d'),
                 'lt' => $toDate->format('Y/m/d'),
-                'format' => 'yyyy/MM/dd||yyyy/MM/dd',
+                'format' => 'yyyy/MM/dd',
             ],
         ]);
 

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -2,6 +2,7 @@
 
 namespace eLife\Search\Api\Elasticsearch;
 
+use DateTimeImmutable;
 use eLife\Search\Api\Query\QueryBuilder;
 use eLife\Search\Api\Query\QueryExecutor;
 
@@ -146,5 +147,18 @@ final class ElasticQueryBuilder implements QueryBuilder
         $exec->setQuery($this);
 
         return $exec;
+    }
+
+    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate): QueryBuilder
+    {
+        $this->query('range', [
+            'sortDate' => [
+                'gte' => $fromDate->format('Y/m/d'),
+                'lt' => $toDate->format('Y/m/d'),
+                'format' => 'yyyy/MM/dd||yyyy/MM/dd',
+            ],
+        ]);
+
+        return $this;
     }
 }

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -159,7 +159,7 @@ final class ElasticQueryBuilder implements QueryBuilder
             $query['gte'] = $fromDate->format(self::ELASTIC_DATETIME_FORMAT);
         }
         if ($toDate) {
-            $query['lt'] = $toDate->format(self::ELASTIC_DATETIME_FORMAT);
+            $query['lte'] = $toDate->format(self::ELASTIC_DATETIME_FORMAT);
         }
         $this->query('range', [
             'sortDate' => $query,

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -11,6 +11,9 @@ final class ElasticQueryBuilder implements QueryBuilder
     private $order;
     private $exec;
 
+    const PHP_DATETIME_FORMAT = 'yyyy/MM/dd HH:mm:ss';
+    const ELASTIC_DATETIME_FORMAT = 'Y/m/d H:i:s';
+
     public function __construct(string $index, ElasticQueryExecutor $exec)
     {
         $this->query['index'] = $index;
@@ -151,12 +154,12 @@ final class ElasticQueryBuilder implements QueryBuilder
 
     public function betweenDates(DateTimeImmutable $fromDate = null, DateTimeImmutable $toDate = null): QueryBuilder
     {
-        $query = ['format' => 'yyyy/MM/dd'];
+        $query = ['format' => self::PHP_DATETIME_FORMAT];
         if ($fromDate) {
-            $query['gte'] = $fromDate->format('Y/m/d');
+            $query['gte'] = $fromDate->format(self::ELASTIC_DATETIME_FORMAT);
         }
         if ($toDate) {
-            $query['lt'] = $toDate->format('Y/m/d');
+            $query['lt'] = $toDate->format(self::ELASTIC_DATETIME_FORMAT);
         }
         $this->query('range', [
             'sortDate' => $query,

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -149,14 +149,17 @@ final class ElasticQueryBuilder implements QueryBuilder
         return $exec;
     }
 
-    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate): QueryBuilder
+    public function betweenDates(DateTimeImmutable $fromDate = null, DateTimeImmutable $toDate = null): QueryBuilder
     {
+        $query = ['format' => 'yyyy/MM/dd'];
+        if ($fromDate) {
+            $query['gte'] = $fromDate->format('Y/m/d');
+        }
+        if ($toDate) {
+            $query['lt'] = $toDate->format('Y/m/d');
+        }
         $this->query('range', [
-            'sortDate' => [
-                'gte' => $fromDate->format('Y/m/d'),
-                'lt' => $toDate->format('Y/m/d'),
-                'format' => 'yyyy/MM/dd',
-            ],
+            'sortDate' => $query,
         ]);
 
         return $this;

--- a/src/Search/Api/Query/MockQueryBuilder.php
+++ b/src/Search/Api/Query/MockQueryBuilder.php
@@ -2,6 +2,8 @@
 
 namespace eLife\Search\Api\Query;
 
+use DateTimeImmutable;
+
 final class MockQueryBuilder implements QueryBuilder
 {
     use RamlRequirement;
@@ -126,5 +128,10 @@ final class MockQueryBuilder implements QueryBuilder
     public function getRawQuery(): array
     {
         return $this->data;
+    }
+
+    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate): QueryBuilder
+    {
+        return $this;
     }
 }

--- a/src/Search/Api/Query/MockQueryBuilder.php
+++ b/src/Search/Api/Query/MockQueryBuilder.php
@@ -130,7 +130,7 @@ final class MockQueryBuilder implements QueryBuilder
         return $this->data;
     }
 
-    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate): QueryBuilder
+    public function betweenDates(DateTimeImmutable $fromDate = null, DateTimeImmutable $toDate = null): QueryBuilder
     {
         return $this;
     }

--- a/src/Search/Api/Query/QueryBuilder.php
+++ b/src/Search/Api/Query/QueryBuilder.php
@@ -2,6 +2,8 @@
 
 namespace eLife\Search\Api\Query;
 
+use DateTimeImmutable;
+
 interface QueryBuilder
 {
     public function searchFor(string $string) : QueryBuilder;
@@ -17,6 +19,8 @@ interface QueryBuilder
     public function whereSubjects(array $subjects = []) : QueryBuilder;
 
     public function whereType(array $types = []) : QueryBuilder;
+
+    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate) : QueryBuilder;
 
     public function getQuery() : QueryExecutor;
 

--- a/src/Search/Api/Query/QueryBuilder.php
+++ b/src/Search/Api/Query/QueryBuilder.php
@@ -20,7 +20,7 @@ interface QueryBuilder
 
     public function whereType(array $types = []) : QueryBuilder;
 
-    public function betweenDates(DateTimeImmutable $fromDate, DateTimeImmutable $toDate) : QueryBuilder;
+    public function betweenDates(DateTimeImmutable $fromDate = null, DateTimeImmutable $toDate = null) : QueryBuilder;
 
     public function getQuery() : QueryExecutor;
 

--- a/src/Search/Api/SearchController.php
+++ b/src/Search/Api/SearchController.php
@@ -3,6 +3,7 @@
 namespace eLife\Search\Api;
 
 use DateTimeImmutable;
+use DateTimeZone;
 use Doctrine\Common\Cache\Cache;
 use eLife\ApiSdk\Model\Subject;
 use eLife\Search\Api\Elasticsearch\ElasticQueryBuilder;
@@ -62,7 +63,7 @@ final class SearchController
 
     private function createValidDateTime(string $format, string $time, $strict = true)
     {
-        $dateTime = DateTimeImmutable::createFromFormat($format, $time);
+        $dateTime = DateTimeImmutable::createFromFormat($format, $time, new DateTimeZone('UTC'));
         $errors = DateTimeImmutable::getLastErrors();
         if (
             ($strict && $errors['warning_count'] !== 0) ||
@@ -89,8 +90,8 @@ final class SearchController
         $fromDateTime = null;
 
         if ($toDate || $fromDate) {
-            $toDateTime = $toDate ? $this->createValidDateTime('Y-m-d', $toDate) : null;
-            $fromDateTime = $fromDate ? $this->createValidDateTime('Y-m-d', $fromDate) : null;
+            $toDateTime = $toDate ? $this->createValidDateTime('Y-m-d H:i:s', $toDate.' 00:00:00') : null;
+            $fromDateTime = $fromDate ? $this->createValidDateTime('Y-m-d H:i:s', $fromDate.' 23:59:59') : null;
             $this->validateDateRange($fromDateTime, $toDateTime);
         }
 

--- a/src/Search/Console.php
+++ b/src/Search/Console.php
@@ -2,6 +2,8 @@
 
 namespace eLife\Search;
 
+use Aws\Sqs\Exception\SqsException;
+use Aws\Sqs\SqsClient;
 use Closure;
 use eLife\Bus\Queue\InternalSqsMessage;
 use eLife\Bus\Queue\WatchableQueue;
@@ -36,6 +38,7 @@ final class Console
     public static $quick_commands = [
         'cache:clear' => ['description' => 'Clears cache'],
         'queue:interactive' => ['description' => 'Manually enqueue item into SQS. (interactive)'],
+        'queue:create' => ['description' => 'Creates queue'],
         'queue:push' => [
             'description' => 'Manually enqueue item into SQS.',
             'args' => [
@@ -50,6 +53,17 @@ final class Console
             'description' => 'Counts (approximately) how many messages are in the queue',
         ],
     ];
+
+    public function queueCreateCommand()
+    {
+        /** @var SqsClient $queue */
+        $queue = $this->app->get('aws.sqs');
+
+        $queue->createQueue([
+            'Region' => $this->config['aws']['region'],
+            'QueueName' => $this->config['aws']['queue_name'],
+        ]);
+    }
 
     public function queuePushCommand(InputInterface $input, OutputInterface $output)
     {
@@ -106,6 +120,8 @@ final class Console
     public function __construct(Application $console, Kernel $app)
     {
         $this->console = $console;
+        $this->config = $app->get('config');
+        $this->logger = $app->get('logger');
         $this->app = $app;
         $this->root = __DIR__.'/../..';
 
@@ -120,14 +136,17 @@ final class Console
 
         // Add commands from the DI container. (for more complex commands.)
         if (GEARMAN_INSTALLED) {
-            $this->console->addCommands([
-                $app->get('console.gearman.worker'),
-                $app->get('console.gearman.client'),
-                $app->get('console.gearman.queue'),
-                $app->get('console.build_index'),
-            ]);
+            try {
+                $this->console->addCommands([
+                    $app->get('console.gearman.worker'),
+                    $app->get('console.gearman.client'),
+                    $app->get('console.gearman.queue'),
+                    $app->get('console.build_index'),
+                ]);
+            } catch (SqsException $e) {
+                $this->logger->debug('Cannot connect to SQS so some commands are not available', ['exception' => $e]);
+            }
         }
-        $this->logger = $app->get('logger');
     }
 
     private function path($path = '')

--- a/src/Search/Console.php
+++ b/src/Search/Console.php
@@ -38,7 +38,7 @@ final class Console
     public static $quick_commands = [
         'cache:clear' => ['description' => 'Clears cache'],
         'queue:interactive' => ['description' => 'Manually enqueue item into SQS. (interactive)'],
-        'queue:create' => ['description' => 'Creates queue'],
+        'queue:create' => ['description' => 'Creates queue [development-only]'],
         'queue:push' => [
             'description' => 'Manually enqueue item into SQS.',
             'args' => [
@@ -56,10 +56,13 @@ final class Console
 
     public function queueCreateCommand()
     {
-        /** @var SqsClient $queue */
-        $queue = $this->app->get('aws.sqs');
+        if ($this->config['debug'] !== true) {
+            throw new LogicException('This method should not be called outside of development');
+        }
+        /* @var SqsClient $queue */
+        $sqs = $this->app->get('aws.sqs');
 
-        $queue->createQueue([
+        $sqs->createQueue([
             'Region' => $this->config['aws']['region'],
             'QueueName' => $this->config['aws']['queue_name'],
         ]);

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace tests\eLife\Search\Web;
+
+/**
+ * @group web
+ */
+class DateRangeTest extends ElasticTestCase
+{
+    public function test_date_range_from_only()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', ['fromDate' => '2016-12-01']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 2);
+
+        $this->jsonRequest('GET', '/search', ['fromDate' => '2016-11-01']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 3);
+    }
+
+    public function test_date_range_to_only()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', ['toDate' => '2016-12-01']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
+
+        $this->jsonRequest('GET', '/search', ['toDate' => '2016-10-01']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 0);
+    }
+
+    public function test_date_range_to_and_from()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', ['fromDate' => '2016-11-01', 'toDate' => '2016-12-01']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
+    }
+}

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -139,7 +139,6 @@ abstract class ElasticTestCase extends WebTestCase
     {
         $response = $this->getResponse();
         if (!$response->isOk()) {
-            var_dump($response);
             $this->fail('Response returned was not 200');
         }
         $json = json_decode($response->getContent());

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\eLife\Search;
+namespace tests\eLife\Search\Web;
 
 use eLife\Search\Api\Elasticsearch\ElasticsearchClient;
 use eLife\Search\Console;
@@ -139,6 +139,7 @@ abstract class ElasticTestCase extends WebTestCase
     {
         $response = $this->getResponse();
         if (!$response->isOk()) {
+            var_dump($response);
             $this->fail('Response returned was not 200');
         }
         $json = json_decode($response->getContent());
@@ -171,12 +172,12 @@ abstract class ElasticTestCase extends WebTestCase
 
     public function createConfiguration()
     {
-        if (file_exists(__DIR__.'/../../../config/local.php')) {
+        if (file_exists(__DIR__.'/../../../../config/local.php')) {
             $this->isLocal = true;
-            $config = include __DIR__.'/../../../config/local.php';
+            $config = include __DIR__.'/../../../../config/local.php';
         } else {
             $this->isLocal = false;
-            $config = include __DIR__.'/../../../config/ci.php';
+            $config = include __DIR__.'/../../../../config/ci.php';
         }
 
         $config['elastic_index'] = 'elife_test';

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -11,6 +11,7 @@ use Symfony\Component\BrowserKit\Client;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 abstract class ElasticTestCase extends WebTestCase
@@ -137,9 +138,10 @@ abstract class ElasticTestCase extends WebTestCase
 
     public function getJsonResponse()
     {
+        /** @var Response $response */
         $response = $this->getResponse();
         if (!$response->isOk()) {
-            $this->fail('Response returned was not 200');
+            $this->fail('Response returned was not 200: '.$response->getContent());
         }
         $json = json_decode($response->getContent());
 

--- a/tests/src/Search/Web/ExampleWebTest.php
+++ b/tests/src/Search/Web/ExampleWebTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\eLife\Search;
+namespace tests\eLife\Search\Web;
 
 /**
  * @group web

--- a/tests/src/Search/Web/FacetCountTest.php
+++ b/tests/src/Search/Web/FacetCountTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\eLife\Search;
+namespace tests\eLife\Search\Web;
 
 /**
  * @group web

--- a/tests/src/Search/Web/SortOrderTest.php
+++ b/tests/src/Search/Web/SortOrderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace tests\eLife\Search;
+namespace tests\eLife\Search\Web;
 
 /**
  * @group web


### PR DESCRIPTION
I've added in the date range filter now conforming to the RAML.

This is the index-less and unoptimised version, but it is working. We can see if it causes any slowdown on the archive pages and review adding month/year fields to each doc and doing a simple lookup