### PR TITLE
ELPP-2093 Fixed subject and type query

### DIFF
--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -30,6 +30,7 @@ final class ElasticQueryBuilder implements QueryBuilder
                     'terms' => [
                         'field' => 'subjects.id',
                         'size' => 15,
+                        'min_doc_count' => 0
                     ],
                     'aggs' => [
                         'name' => [
@@ -63,8 +64,35 @@ final class ElasticQueryBuilder implements QueryBuilder
 
     private function postQuery(string $key, $value)
     {
-        $this->query['body']['post_filter'] = $this->query['body']['post_filter'] ?? [];
-        $this->query['body']['post_filter']['terms'][$key] = $value;
+        /*
+         "post_filter": {
+                "query": {
+                   "bool" : {
+                        "must" : [
+                            {"terms": {"subjects.id": ["cell-biology"]}},
+                            {"terms": { "_type": ["research-article"]}}
+                        ]
+                    }
+                }
+            },
+         */
+        if (isset($this->query['body']['post_filter']['terms'])) {
+            $firstFilter = $this->query['body']['post_filter']['terms'];
+            $secondFilter = [];
+            $secondFilter[$key] = $value;
+            unset($this->query['body']['post_filter']['terms']);
+            $this->query['body']['post_filter']['query']['bool']['must'] = [
+                ['terms' => $firstFilter],
+                ['terms' => $secondFilter]
+            ];
+        } elseif (isset($this->query['body']['post_filter']['query']['bool']['must'])) {
+            $nthFilter = [];
+            $nthFilter[$key] = $value;
+            $this->query['body']['post_filter']['query']['bool']['must'][] = ['terms' => $nthFilter];
+        } else {
+            $this->query['body']['post_filter'] = $this->query['body']['post_filter'] ?? [];
+            $this->query['body']['post_filter']['terms'][$key] = $value;
+        }
     }
 
     private function query($key, array $body)

--- a/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
+++ b/src/Search/Api/Elasticsearch/ElasticQueryBuilder.php
@@ -30,7 +30,7 @@ final class ElasticQueryBuilder implements QueryBuilder
                     'terms' => [
                         'field' => 'subjects.id',
                         'size' => 15,
-                        'min_doc_count' => 0
+                        'min_doc_count' => 0,
                     ],
                     'aggs' => [
                         'name' => [
@@ -83,7 +83,7 @@ final class ElasticQueryBuilder implements QueryBuilder
             unset($this->query['body']['post_filter']['terms']);
             $this->query['body']['post_filter']['query']['bool']['must'] = [
                 ['terms' => $firstFilter],
-                ['terms' => $secondFilter]
+                ['terms' => $secondFilter],
             ];
         } elseif (isset($this->query['body']['post_filter']['query']['bool']['must'])) {
             $nthFilter = [];

--- a/src/Search/Api/Elasticsearch/Response/SearchResponse.php
+++ b/src/Search/Api/Elasticsearch/Response/SearchResponse.php
@@ -82,13 +82,11 @@ final class SearchResponse implements ElasticResponse, QueryResponse
         if (isset($this->aggregations['subject_agg']['name']['buckets'])) {
             $types = [];
             foreach ($this->aggregations['subject_agg']['name']['buckets'] as $bucket) {
-                if (isset($bucket['name']['buckets'][0]['key'])) {
-                    $types[] = [
-                        'id' => $bucket['key'],
-                        'name' => $bucket['name']['buckets'][0]['key'],
-                        'results' => $bucket['doc_count'],
-                    ];
-                }
+                $types[] = [
+                    'id' => $bucket['key'],
+                    'name' => $bucket['name']['buckets'][0]['key'] ?? null,
+                    'results' => $bucket['doc_count'],
+                ];
             }
 
             return $types;

--- a/src/Search/Api/SearchController.php
+++ b/src/Search/Api/SearchController.php
@@ -160,7 +160,7 @@ final class SearchController
         $words = explode('-', $id);
         $words[0] = ucfirst($words[0]);
         $words = array_map(function ($word) {
-            if (in_array($word, ['and', 'the', 'a', 'of', 'in']) === false) {
+            if (in_array($word, ['the', 'a', 'of', 'in']) === false) {
                 return ucfirst($word);
             }
 

--- a/src/Search/Api/SearchController.php
+++ b/src/Search/Api/SearchController.php
@@ -12,7 +12,6 @@ use eLife\Search\Api\Elasticsearch\Response\ErrorResponse;
 use eLife\Search\Api\Query\QueryResponse;
 use eLife\Search\Api\Response\SearchResponse;
 use eLife\Search\Api\Response\TypesResponse;
-use function GuzzleHttp\json_encode;
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\Serializer;
 use Psr\Log\LoggerInterface;
@@ -160,21 +159,24 @@ final class SearchController
     {
         $words = explode('-', $id);
         $words[0] = ucfirst($words[0]);
-        $words = array_map(function($word) {
+        $words = array_map(function ($word) {
             if (in_array($word, ['and', 'the', 'a', 'of', 'in']) === false) {
                 return ucfirst($word);
             }
+
             return $word;
         }, $words);
-        return implode(' ',$words);
+
+        return implode(' ', $words);
     }
 
     public function hydrateSubjects(array $subjects)
     {
-        return array_map(function($subject) {
-            if($subject['name'] === null) {
+        return array_map(function ($subject) {
+            if ($subject['name'] === null) {
                 $subject['name'] = $this->getSubjectName($subject['id']);
             }
+
             return $subject;
         }, $subjects);
     }

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -40,7 +40,7 @@ abstract class ElasticTestCase extends WebTestCase
                         'statement' => 'This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.',
                         'license' => 'CC-BY-4.0',
                     ],
-                    'title' => 'Mitochondrial support of persistent presynaptic vesicle mobilization with age-dependent synaptic growth after LTP',
+                    'title' => 'BUZZWORD ONLY FOUND HERE Mitochondrial support of persistent presynaptic vesicle mobilization with age-dependent synaptic growth after LTP',
                     'authorLine' => 'Heather L Smith et al',
                     'versionDate' => '2016-12-19T00:00:00Z',
                     'researchOrganisms' => [
@@ -129,6 +129,43 @@ abstract class ElasticTestCase extends WebTestCase
                     ],
                     'elocationId' => 'e15276',
                     'id' => '15276',
+                    'stage' => 'published',
+                ];
+                break;
+            case 3:
+                return [
+                    'status' => 'poa',
+                    'volume' => 6,
+                    'doi' => '10.7554/eLife.15278',
+                    'type' => 'correction',
+                    'version' => 2,
+                    'copyright' => [
+                        'holder' => 'Smith et al',
+                        'statement' => 'This article is distributed under the terms of the Creative Commons Attribution License permitting unrestricted use and redistribution provided that the original author and source are credited.',
+                        'license' => 'CC-BY-4.0',
+                    ],
+                    'title' => 'Mitochondrial support of persistent presynaptic vesicle mobilization with age-dependent synaptic growth after LTP',
+                    'authorLine' => 'Heather L Smith et al',
+                    'versionDate' => '2016-12-19T00:00:00Z',
+                    'researchOrganisms' => [
+                        'Rat',
+                    ],
+                    'published' => '2017-01-19T00:00:00Z',
+                    'sortDate' => '2017-01-19T00:00:00Z',
+                    'statusDate' => '2017-01-19T00:00:00Z',
+                    'pdf' => 'https://publishing-cdn.elifesciences.org/15276/elife-15276-v1.pdf',
+                    'subjects' => [
+                        [
+                            'id' => 'neuroscience',
+                            'name' => 'Neuroscience',
+                        ],
+                        [
+                            'id' => 'immunology',
+                            'name' => 'Immunology',
+                        ],
+                    ],
+                    'elocationId' => 'e15278',
+                    'id' => '15278',
                     'stage' => 'published',
                 ];
                 break;

--- a/tests/src/Search/Web/TypeSubjectFilterTest.php
+++ b/tests/src/Search/Web/TypeSubjectFilterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace tests\eLife\Search\Web;
+
+/**
+ * @group web
+ */
+class TypeSubjectFilterTest extends ElasticTestCase
+{
+    public function test_subject_filtering_works()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+            $this->getArticleFixture(3),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', ['subject' => ['neuroscience']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 3);
+
+        $this->jsonRequest('GET', '/search', ['subject' => ['immunology']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 2);
+
+        $this->jsonRequest('GET', '/search', ['subject' => ['neuroscience', 'immunology']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 4);
+    }
+
+    public function test_type_filtering_works()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+            $this->getArticleFixture(3),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', ['type' => ['research-article']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 3);
+
+        $this->jsonRequest('GET', '/search', ['type' => ['correction']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
+
+        $this->jsonRequest('GET', '/search', ['type' => ['research-article', 'correction']]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 4);
+    }
+
+    public function test_subject_and_type_filtering_works()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+            $this->getArticleFixture(3),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', [
+            'subject' => ['immunology'],
+            'type' => ['research-article'],
+        ]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', [
+            'subject' => ['immunology', 'neuroscience'],
+            'type' => ['research-article'],
+        ]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 3);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', [
+            'subject' => ['immunology'],
+            'type' => ['research-article', 'correction'],
+        ]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 2);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', [
+            'subject' => ['immunology', 'neuroscience'],
+            'type' => ['research-article', 'correction'],
+        ]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 4);
+    }
+
+    public function test_for_subject_and_type_filtering_works()
+    {
+        $this->addDocumentsToElasticSearch([
+            $this->getArticleFixture(0),
+            $this->getArticleFixture(1),
+            $this->getArticleFixture(2),
+            $this->getArticleFixture(3),
+        ]);
+
+        $this->newClient();
+        $this->jsonRequest('GET', '/search', [
+            'for' => 'BUZZWORD ONLY FOUND HERE',
+            'subject' => ['neuroscience'],
+            'type' => ['research-article'],
+        ]);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
+
+        $foundImmunology = false;
+        array_walk($response->subjects, function ($subject) use (&$foundImmunology) {
+            if ($subject->id === 'immunology') {
+                $foundImmunology = true;
+                $this->assertEquals($subject->count, 0);
+            }
+        });
+
+        $this->assertTrue($foundImmunology, 'Did not find empty subject');
+    }
+}

--- a/tests/src/Search/Web/TypeSubjectFilterTest.php
+++ b/tests/src/Search/Web/TypeSubjectFilterTest.php
@@ -117,7 +117,7 @@ class TypeSubjectFilterTest extends ElasticTestCase
         array_walk($response->subjects, function ($subject) use (&$foundImmunology) {
             if ($subject->id === 'immunology') {
                 $foundImmunology = true;
-                $this->assertEquals($subject->count, 0);
+                $this->assertEquals($subject->results, 0);
             }
         });
 


### PR DESCRIPTION
This should now return results in the correct format, without 500 errors and with all subjects and types intact. I'm using (a fairly accurate) workaround for the subject names pending the bus-sdk fixes. This allows this fix to be fast tracked (not requiring a reindexing) for demos and such.