### PR TITLE
Scripts that wait for ElasticSearch to respond on startup

### DIFF
--- a/bin/wait-for-running-elasticsearch
+++ b/bin/wait-for-running-elasticsearch
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+while true;
+do
+    nodes=$(curl localhost:9200/_nodes/_local | jq ".nodes | length")
+    if [ "$nodes" -eq 1 ]; then
+        echo "ElasticSearch is ready, seeing 1 node through _nodes API"
+        exit 0
+    else
+        echo "ElasticSearch API not responding yet"
+        sleep 1
+    fi
+done


### PR DESCRIPTION
Failures like
```
04:39:22 [107.21.192.235] out: [Elasticsearch\Common\Exceptions\NoNodesAvailableException]
04:39:22 [107.21.192.235] out:   No alive nodes found in your cluster
```
at
https://ci--alfred.elifesciences.org/job/process-clean-end2end/25/console
can be avoided using this script in the build.