### PR TITLE
Default dev build should be green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /build/
 /config/local.php
+/index.json
 /var/
 /vendor/
 !.gitkeep

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-env="${1:-ci}"
+env="${ENVIRONMENT_NAME:-ci}"
 
 rm -f build/*.xml
 proofreader src/ tests/ web/


### PR DESCRIPTION
`./project_tests.sh` runs locally.

Postponed issue is that since the index is cleared by the Salt highstate, `php bin/console search:setup -d --env=dev` needs to be run before `./project_tests.sh` can be run again.