### PR TITLE
ELPP-3180 Adding Gearman and ElasticSearch hostnames

### DIFF
--- a/config/end2end.php
+++ b/config/end2end.php
@@ -2,7 +2,8 @@
 
 return [
     'debug' => true,
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['end2end--search--1.elife.internal'],
+    'elastic_servers' => ['http://end2end--search--1.elife.internal:9200'],
     'api_url' => 'http://end2end--gateway.elife.internal/',
     'api_requests_batch' => 20,
     'aws' => [

--- a/config/prod.php
+++ b/config/prod.php
@@ -3,7 +3,8 @@
 use Monolog\Logger;
 
 return [
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['prod--search--1.elife.internal'],
+    'elastic_servers' => ['http://prod--search--1.elife.internal:9200'],
     'api_url' => 'http://prod--gateway.elife.internal/',
     'api_requests_batch' => 20,
     'aws' => [


### PR DESCRIPTION
Only matters for follower nodes, e.g. `search--end2end--2`.