### PR TITLE
Forcing ENVIRONMENT_NAME from cli argument

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -15,6 +15,8 @@ $input = new ArgvInput();
 if (!defined('GEARMAN_INSTALLED')) {
     define('GEARMAN_INSTALLED', class_exists('GearmanClient'));
 }
+$env = $input->getParameterOption(['--env', '-e']);
+putenv("ENVIRONMENT_NAME={$env}");
 $app = new Kernel($config);
 $output = new ConsoleOutput();
 $app->get('logger')->pushHandler(new ConsoleHandler($output));


### PR DESCRIPTION
Upstart does not provide environment variables, so this is the only way
to provide the environment at the moment.