### PR TITLE
Wait for cluster state on startup of Elasticsearch

### DIFF
--- a/bin/wait-for-running-elasticsearch
+++ b/bin/wait-for-running-elasticsearch
@@ -10,5 +10,16 @@ do
     else
         echo "ElasticSearch API not responding yet"
         sleep 1
+        continue
+    fi
+
+    color=$(curl localhost:9200/_cluster/health | jq -r ".status")
+    if [ "$color" == "yellow" ]; then
+        echo "ElasticSearch is ready, seeing color $color"
+        exit 0
+    else
+        echo "ElasticSearch is not ready yet, seeing color $color"
+        sleep 1
+        continue
     fi
 done


### PR DESCRIPTION
Condition exacerbated by the reliance on Elasticsearch for metadata.
Seeing 1 node is not enough, waiting for the cluster state to become
`yellow` instead of `red` is also necessary for reads to be performed.