### PR TITLE
Change pipelines to trigger reindexes on one node only

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ elifePipeline {
                     preliminaryStep: {
                         builderDeployRevision 'search--end2end', commit
                         builderSmokeTests 'search--end2end', '/srv/search'
-                        builderCmd 'search--end2end', "cd /srv/search; ./bin/reindex end2end elife_search_${env.BUILD_NUMBER}"
+                        builderCmdNode 'search--end2end', 1, "cd /srv/search; ./bin/reindex end2end elife_search_${env.BUILD_NUMBER}"
                     }
                 ],
                 marker: 'search'

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -10,6 +10,6 @@ elifePipeline {
         elifeGitMoveToBranch commit, 'master'
         builderDeployRevision 'search--prod', commit
         builderSmokeTests 'search--prod', '/srv/search'
-        builderCmd 'search--prod', "cd /srv/search; ./bin/reindex-on-demand prod elife_search_${env.BUILD_NUMBER}"
+        builderCmdNode 'search--prod', 1, "cd /srv/search; ./bin/reindex-on-demand prod elife_search_${env.BUILD_NUMBER}"
     }
 }


### PR DESCRIPTION
The state is shared between nodes, so no need to do it twice in parallel (and there is no support for it).