### PR TITLE
Date filters exclude boundaries

### DIFF
--- a/src/Search/Api/SearchController.php
+++ b/src/Search/Api/SearchController.php
@@ -101,9 +101,9 @@ final class SearchController
         }
 
         if ($endDate || $startDate) {
-            $startDateTime = $endDate ? $this->createValidDateTime('Y-m-d H:i:s', $endDate.' 00:00:00') : null;
-            $endDateTime = $startDate ? $this->createValidDateTime('Y-m-d H:i:s', $startDate.' 23:59:59') : null;
-            $this->validateDateRange($endDateTime, $startDateTime);
+            $startDateTime = $startDate ? $this->createValidDateTime('Y-m-d H:i:s', $startDate.' 00:00:00') : null;
+            $endDateTime = $endDate ? $this->createValidDateTime('Y-m-d H:i:s', $endDate.' 23:59:59') : null;
+            $this->validateDateRange($startDateTime, $endDateTime);
         }
 
         /** @var ElasticQueryBuilder $query */
@@ -121,7 +121,7 @@ final class SearchController
         }
 
         if ($startDateTime || $endDateTime) {
-            $query->betweenDates($endDateTime, $startDateTime);
+            $query->betweenDates($startDateTime, $endDateTime);
         }
 
         $query = $query

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -132,7 +132,7 @@ final class ResearchArticleWorkflow implements Workflow
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
 
-        $sortDate = $article->getStatusDate() ? $article->getStatusDate() : $article->getPublishedDate();
+        $sortDate = $article->getStatusDate();
         $this->addSortDate($articleObject, $sortDate);
 
         $this->logger->debug('Article<'.$article->getId().'> Detected type '.($article->getType() ?? 'research-article'));

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -23,6 +23,11 @@ class DateRangeTest extends ElasticTestCase
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01']);
         $response = $this->getJsonResponse();
         $this->assertEquals($response->total, 3);
+
+        // boundary is included
+        $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-19']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 2);
     }
 
     public function test_date_range_end_only()
@@ -41,6 +46,11 @@ class DateRangeTest extends ElasticTestCase
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-10-01']);
         $response = $this->getJsonResponse();
         $this->assertEquals($response->total, 0);
+
+        // boundary
+        $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-05']);
+        $response = $this->getJsonResponse();
+        $this->assertEquals($response->total, 1);
     }
 
     public function test_date_range_start_and_end()

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -27,7 +27,7 @@ class DateRangeTest extends ElasticTestCase
         // boundary is included
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-19']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(2, $response->total, "The date lower boundary is being excluded");
+        $this->assertEquals(2, $response->total, 'The date lower boundary is being excluded');
     }
 
     public function test_date_range_end_only()
@@ -50,7 +50,7 @@ class DateRangeTest extends ElasticTestCase
         // boundary
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-05']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(1, $response->total, "The date upper boundary is being excluded");
+        $this->assertEquals(1, $response->total, 'The date upper boundary is being excluded');
     }
 
     public function test_date_range_start_and_end()

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -2,6 +2,8 @@
 
 namespace tests\eLife\Search\Web;
 
+use stdClass;
+
 /**
  * @group web
  */
@@ -18,16 +20,16 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(2, $response->total);
+        $this->assertIds(['15275', '15276'], $response);
 
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(3, $response->total);
+        $this->assertIds(['15275', '15276', '19662'], $response);
 
         // boundary is included
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-19']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(2, $response->total, 'The date lower boundary is being excluded');
+        $this->assertIds(['15275', '15276'], $response, 'The date lower boundary is being excluded');
     }
 
     public function test_date_range_end_only()
@@ -41,16 +43,16 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(1, $response->total);
+        $this->assertIds(['19662'], $response);
 
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-10-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(0, $response->total);
+        $this->assertIds([], $response);
 
         // boundary
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-05']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(1, $response->total, 'The date upper boundary is being excluded');
+        $this->assertIds(['19662'], $response, 'The date upper boundary is being excluded');
     }
 
     public function test_date_range_start_and_end()
@@ -64,6 +66,16 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01', 'end-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
-        $this->assertEquals(1, $response->total);
+        $this->assertIds(['19662'], $response);
+    }
+
+    private function assertIds(array $expected, stdClass $response, $message = null)
+    {
+        $ids = [];
+        foreach ($response->items as $item) {
+            $ids[] = $item->id;
+        }
+        sort($ids);
+        $this->assertEquals($expected, $ids, $message);
     }
 }

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -18,16 +18,16 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 2);
+        $this->assertEquals(2, $response->total);
 
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 3);
+        $this->assertEquals(3, $response->total);
 
         // boundary is included
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-19']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 2);
+        $this->assertEquals(2, $response->total, "The date lower boundary is being excluded");
     }
 
     public function test_date_range_end_only()
@@ -41,16 +41,16 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 1);
+        $this->assertEquals(1, $response->total);
 
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-10-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 0);
+        $this->assertEquals(0, $response->total);
 
         // boundary
         $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-05']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 1);
+        $this->assertEquals(1, $response->total, "The date upper boundary is being excluded");
     }
 
     public function test_date_range_start_and_end()
@@ -64,6 +64,6 @@ class DateRangeTest extends ElasticTestCase
         $this->newClient();
         $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01', 'end-date' => '2016-12-01']);
         $response = $this->getJsonResponse();
-        $this->assertEquals($response->total, 1);
+        $this->assertEquals(1, $response->total);
     }
 }

--- a/tests/src/Search/Web/DateRangeTest.php
+++ b/tests/src/Search/Web/DateRangeTest.php
@@ -16,7 +16,7 @@ class DateRangeTest extends ElasticTestCase
         ]);
 
         $this->newClient();
-        $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-01']);
+        $this->jsonRequest('GET', '/search', ['start-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
         $this->assertEquals(2, $response->total);
 
@@ -39,7 +39,7 @@ class DateRangeTest extends ElasticTestCase
         ]);
 
         $this->newClient();
-        $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-01']);
+        $this->jsonRequest('GET', '/search', ['end-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
         $this->assertEquals(1, $response->total);
 
@@ -62,7 +62,7 @@ class DateRangeTest extends ElasticTestCase
         ]);
 
         $this->newClient();
-        $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01', 'end-date' => '2016-12-01']);
+        $this->jsonRequest('GET', '/search', ['start-date' => '2016-11-01', 'end-date' => '2016-12-13']);
         $response = $this->getJsonResponse();
         $this->assertEquals(1, $response->total);
     }

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -159,7 +159,7 @@ abstract class ElasticTestCase extends WebTestCase
                     ],
                     'version' => 3,
                     'published' => '2016-11-18T00:00:00Z',
-                    'sortDate' => '2016-11-18T00:00:00Z',
+                    'sortDate' => '2016-12-05T16:36:45Z',
                     'statusDate' => '2016-12-05T16:36:45Z',
                     'pdf' => 'https://publishing-cdn.elifesciences.org/19662/elife-19662-v3.pdf',
                     'subjects' => [

--- a/tests/src/Search/Web/ElasticTestCase.php
+++ b/tests/src/Search/Web/ElasticTestCase.php
@@ -191,9 +191,9 @@ abstract class ElasticTestCase extends WebTestCase
                     'researchOrganisms' => [
                         'Rat',
                     ],
-                    'published' => '2016-12-19T00:00:00Z',
-                    'sortDate' => '2016-12-19T00:00:00Z',
-                    'statusDate' => '2016-12-19T00:00:00Z',
+                    'published' => '2016-12-19T12:42:00Z',
+                    'sortDate' => '2016-12-19T12:42:00Z',
+                    'statusDate' => '2016-12-19T12:42:00Z',
                     'pdf' => 'https://publishing-cdn.elifesciences.org/15276/elife-15276-v1.pdf',
                     'subjects' => [
                         [


### PR DESCRIPTION
Excluding because the variables were mixed up and were setting 23:59:59 for the start date and 00:00:00 for the end date.