### PR TITLE
Use correct client in index deletion

### DIFF
--- a/bin/ci-lifecycle
+++ b/bin/ci-lifecycle
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+. bin/ci-process-bootstrap
+
+echo $environment
+temporary_index_name=elife_search_temporary_lifecycle_test
+./bin/console search:setup --index="$temporary_index_name" --delete --env="$environment"
+./bin/console index:delete "$temporary_index_name" --env="$environment"

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -7,6 +7,9 @@ rm -f build/*.xml
 proofreader src/ tests/ web/
 vendor/bin/phpunit --log-junit build/phpunit.xml
 
+echo "Creating, deleting an index"
+bin/ci-lifecycle "$env"
+
 echo "Importing api-dummy"
 bin/ci-import "$env"
 

--- a/src/Search/Console.php
+++ b/src/Search/Console.php
@@ -237,7 +237,7 @@ final class Console
 
     public function indexDeleteCommand(InputInterface $input, OutputInterface $output)
     {
-        $client = $this->kernel->get('elastic.client.read');
+        $client = $this->kernel->get('elastic.client.plain');
         $indexName = $input->getArgument('index_name');
         $this->logger->info("Deleting index {$indexName}");
         $client->deleteIndex($indexName);

--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -329,7 +329,7 @@ final class Kernel implements MinimalKernel
             return new ElasticsearchKeyValueStore(
                 new PlainElasticsearchClient(
                     $app['elastic.elasticsearch.plain'],
-                    $indexName ?? ElasticSearchKeyValueStore::INDEX_NAME
+                    ElasticSearchKeyValueStore::INDEX_NAME
                 )
             );
         };
@@ -347,6 +347,13 @@ final class Kernel implements MinimalKernel
                 $app['elastic.elasticsearch'],
                 $this->indexMetadata()->operation(IndexMetadata::READ),
                 $app['config']['elastic_force_sync']
+            );
+        };
+
+        $app['elastic.client.plain'] = function (Application $app) {
+            return new PlainElasticsearchClient(
+                $app['elastic.elasticsearch.plain'],
+                $this->indexMetadata()->write()
             );
         };
 
@@ -479,10 +486,7 @@ final class Kernel implements MinimalKernel
 
         $app['console.build_index'] = function (Application $app) {
             return new BuildIndexCommand(
-                new PlainElasticsearchClient(
-                    $app['elastic.elasticsearch.plain'],
-                    $this->indexMetadata()->write()
-                ),
+                $app['elastic.client.plain'],
                 $app['logger']
             );
         };


### PR DESCRIPTION
Includes new automated test exercising that command, which was only used in `prod`.