### PR TITLE
Removed debug mode from end2end

### DIFF
--- a/config/ci.php
+++ b/config/ci.php
@@ -3,7 +3,6 @@
 require_once __DIR__.'/extra/gearman_shim.php';
 
 return [
-    'debug' => false,
     'validate' => true,
     'api_url' => 'http://localhost:8080',
     'ttl' => 0,

--- a/config/continuumtest.php
+++ b/config/continuumtest.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'debug' => true,
     'gearman_servers' => ['localhost'],
     'api_url' => 'http://continuumtest--gateway.elife.internal/',
     'api_requests_batch' => 20,

--- a/config/end2end.php
+++ b/config/end2end.php
@@ -1,7 +1,6 @@
 <?php
 
 return [
-    'debug' => true,
     'gearman_servers' => ['end2end--search--1.elife.internal'],
     'elastic_servers' => ['http://end2end--search--1.elife.internal:9200'],
     'api_url' => 'http://end2end--gateway.elife.internal/',


### PR DESCRIPTION
To make it really prod-like, and because it's not needed outside of dev. The default value is `false`.
  