### PR TITLE
Updated elife/api-sdk to b1245f2: Annual report drop image

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,12 +548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "06e690a91bec0b989ea4fb4a1db6362a4db81fe5"
+                "reference": "3636c5ceea8bdf5fa50902a9b6940cb42bc44138"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/06e690a91bec0b989ea4fb4a1db6362a4db81fe5",
-                "reference": "06e690a91bec0b989ea4fb4a1db6362a4db81fe5",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/3636c5ceea8bdf5fa50902a9b6940cb42bc44138",
+                "reference": "3636c5ceea8bdf5fa50902a9b6940cb42bc44138",
                 "shasum": ""
             },
             "conflict": {
@@ -565,7 +565,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API specification",
-            "time": "2018-07-19T12:50:10+00:00"
+            "time": "2018-07-31T10:50:36+00:00"
         },
         {
             "name": "elife/api-client",
@@ -677,12 +677,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "39d64be9da86987fbcc5e2acfeade6a1d5ec5a28"
+                "reference": "b1245f2a3f9c13f0d8f45693b4ea76bbdec87ceb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/39d64be9da86987fbcc5e2acfeade6a1d5ec5a28",
-                "reference": "39d64be9da86987fbcc5e2acfeade6a1d5ec5a28",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/b1245f2a3f9c13f0d8f45693b4ea76bbdec87ceb",
+                "reference": "b1245f2a3f9c13f0d8f45693b4ea76bbdec87ceb",
                 "shasum": ""
             },
             "require": {
@@ -718,7 +718,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2018-07-19T13:38:25+00:00"
+            "time": "2018-08-03T09:41:09+00:00"
         },
         {
             "name": "elife/api-validator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/60/display/redirect which resulted in this pull request.