### PR TITLE
Updated elife/api-sdk to 51c893b: Mock event or job-advert calls number or id

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -677,12 +677,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "de800ac59ed67824a245b1c529a74276eb7b5ea9"
+                "reference": "51c893b8d0b37345d082ced4eb9d7c64f35b5986"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/de800ac59ed67824a245b1c529a74276eb7b5ea9",
-                "reference": "de800ac59ed67824a245b1c529a74276eb7b5ea9",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/51c893b8d0b37345d082ced4eb9d7c64f35b5986",
+                "reference": "51c893b8d0b37345d082ced4eb9d7c64f35b5986",
                 "shasum": ""
             },
             "require": {
@@ -718,7 +718,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2018-10-04T10:38:07+00:00"
+            "time": "2018-10-09T08:31:25+00:00"
         },
         {
             "name": "elife/api-validator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/70/display/redirect which resulted in this pull request.