### PR TITLE
Rate limit all for= search queries

### DIFF
--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -585,6 +585,10 @@ final class Kernel implements MinimalKernel
             $response->headers->set('X-Kong-Limit', 'highpages=1');
         }
 
+        if ($request->query->get('for', null)) {
+            $response->headers->set('X-Kong-Limit', 'highpages=1');
+        }
+
         return $response;
     }
 }


### PR DESCRIPTION
Assuming Kong rate limiting works well (which is a leap), trying to use it to shut off the crawlers that are overloading this service.