### PR TITLE
Fail when Gearman can't be reached

### DIFF
--- a/src/Search/Kernel.php
+++ b/src/Search/Kernel.php
@@ -365,10 +365,7 @@ final class Kernel implements MinimalKernel
         $app['gearman.client'] = function (Application $app) {
             $worker = new GearmanClient();
             foreach ($app['config']['gearman_servers'] as $server) {
-                try {
-                    $worker->addServer($server);
-                } catch (Throwable $e) {
-                }
+                $worker->addServer($server);
             }
 
             return $worker;


### PR DESCRIPTION
Don't hide exceptions in connecting to Gearman.

Discovered in https://github.com/elifesciences/search-formula/pull/20

I wouldn't merge this now as we need a stable pipeline to test it in all environments, there may be corner cases lurking.

Edit: it also probably doesn't help for the "connection hanging" scenario.