### PR TITLE
Fix: dev config, changes gearman server from 'localhost' to '127.0.0.1'

### DIFF
--- a/config/dev.php
+++ b/config/dev.php
@@ -7,7 +7,7 @@ return [
     'validate' => true,
     'api_url' => 'http://localhost:8080',
     'ttl' => 0,
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['127.0.0.1'],
     'gearman_auto_restart' => false,
     'elastic_force_sync' => true,
     'elastic_logging' => true,


### PR DESCRIPTION
* changes gearman server from 'localhost' to '127.0.0.1'

stops console from hanging in vagrant using Ubuntu 16.04. 

See: https://github.com/elifesciences/search-formula/pull/20