### PR TITLE
Feature: delay smoke tests (temporary)

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -4,5 +4,8 @@ set -ex
 attempts=3
 delay=10
 
+# temporary, to get 18.04 formula branch passing. remove once upgraded. this delay is incorporated there
+sleep 20 
+
 retry ./smoke_tests_app.sh $attempts $delay
 retry ./smoke_tests_elasticsearch.sh $attempts $delay


### PR DESCRIPTION
added temporary delay before running smoke tests to get search-formula build working.

this change is incorporated into the 18.04 formula but build cannot go green until the original formula successfully passes