### PR TITLE
Fix: adds an exception to calling the smoke tests

### DIFF
--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 set -ex
 
+hostname | grep 'fresh-follower-node' && {
+    echo "This is a follower node without an elasticsearch leader. Smoke tests cannot be run."
+    exit 0
+}
+
 attempts=3
 delay=10
-
-# temporary, to get 18.04 formula branch passing. remove once upgraded. this delay is incorporated there
-sleep 20 
 
 retry ./smoke_tests_app.sh $attempts $delay
 retry ./smoke_tests_elasticsearch.sh $attempts $delay


### PR DESCRIPTION
currently the smoke tests are *not* being called during the search-formula CI and the build is passing.

if they were being called, then the `fresh-follower-node` variant would be failing because there is no ElasticSearch instance to connect to.

the 18.04 search-formula PR *does* use the smoke tests during CI and is currently failing because of this.

