### PR TITLE
changes gearman_server from hostname to '127.0.0.1' in all cases

### DIFF
--- a/config/ci.php
+++ b/config/ci.php
@@ -7,7 +7,7 @@ return [
     'api_url' => 'http://localhost:8080',
     'ttl' => 0,
     'elastic_force_sync' => true,
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['127.0.0.1'],
     'elastic_logging' => true,
     'gearman_auto_restart' => false,
     'aws' => [

--- a/config/continuumtest.php
+++ b/config/continuumtest.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['127.0.0.1'],
     'api_url' => 'http://continuumtest--gateway.elife.internal/',
     'api_requests_batch' => 20,
     'rate_limit_minimum_page' => 21,

--- a/config/end2end.php
+++ b/config/end2end.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'gearman_servers' => ['end2end--search--1.elife.internal'],
+    'gearman_servers' => ['127.0.0.1'],
     'elastic_servers' => ['http://end2end--search--1.elife.internal:9200'],
     'api_url' => 'http://end2end--gateway.elife.internal/',
     'api_requests_batch' => 20,

--- a/config/prod.php
+++ b/config/prod.php
@@ -3,7 +3,7 @@
 use Monolog\Logger;
 
 return [
-    'gearman_servers' => ['prod--search--1.elife.internal'],
+    'gearman_servers' => ['127.0.0.1'],
     'elastic_servers' => ['http://prod--search--1.elife.internal:9200'],
     'api_url' => 'http://prod--gateway.elife.internal/',
     'api_requests_batch' => 20,


### PR DESCRIPTION
I think 'localhost' works as well on ec2 (as demonstrated on `--ci`) but not on vagrant, where it just hangs. I don't recall if we got the hanging behaviour in CI 

at time of writing end2end is [currently in a broken state](https://github.com/elifesciences/issues/issues/4789) because of this