### PR TITLE
Configure gearman_servers like dev

### DIFF
--- a/config/ci.php
+++ b/config/ci.php
@@ -7,7 +7,7 @@ return [
     'api_url' => 'http://localhost:8080',
     'ttl' => 0,
     'elastic_force_sync' => true,
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['127.0.0.1'],
     'elastic_logging' => true,
     'gearman_auto_restart' => false,
     'aws' => [

--- a/config/continuumtest.php
+++ b/config/continuumtest.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'gearman_servers' => ['localhost'],
+    'gearman_servers' => ['127.0.0.1'],
     'api_url' => 'http://continuumtest--gateway.elife.internal/',
     'api_requests_batch' => 20,
     'rate_limit_minimum_page' => 21,


### PR DESCRIPTION
Which doesn't hang. See https://github.com/elifesciences/search-formula/pull/42 for empirical investigation.

Doesn't affect `prod`.