### PR TITLE
Remove environment arguments

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ elifePipeline {
                         builderDeployRevision 'search--end2end', commit
                         builderCmdNode 'search--end2end', 1, 'cd /srv/search; ./bin/wait-for-running-elasticsearch'
                         builderSmokeTests 'search--end2end', '/srv/search'
-                        builderCmdNode 'search--end2end', 1, "cd /srv/search; ./bin/reindex end2end elife_search_${env.BUILD_NUMBER}"
+                        builderCmdNode 'search--end2end', 1, "cd /srv/search; ./bin/reindex elife_search_${env.BUILD_NUMBER}"
                     }
                 ],
                 marker: 'search'

--- a/Jenkinsfile.prod
+++ b/Jenkinsfile.prod
@@ -10,6 +10,6 @@ elifePipeline {
         elifeGitMoveToBranch commit, 'master'
         builderDeployRevision 'search--prod', commit
         builderSmokeTests 'search--prod', '/srv/search'
-        builderCmdNode 'search--prod', 1, "cd /srv/search; ./bin/reindex-on-demand prod elife_search_${env.BUILD_NUMBER}"
+        builderCmdNode 'search--prod', 1, "cd /srv/search; ./bin/reindex-on-demand elife_search_${env.BUILD_NUMBER}"
     }
 }

--- a/bin/ci-import
+++ b/bin/ci-import
@@ -2,18 +2,18 @@
 set -e
 . bin/ci-process-bootstrap
 
-./bin/console keyvalue:setup --env="$environment"
-./bin/console keyvalue:store index-metadata '{"write":"elife_search", "read":"elife_search"}' --env="$environment"
-./bin/console search:setup --index="elife_search" --delete --env="$environment"
+./bin/console keyvalue:setup
+./bin/console keyvalue:store index-metadata '{"write":"elife_search", "read":"elife_search"}'
+./bin/console search:setup --index="elife_search" --delete
 
-./bin/console queue:clean --env="$environment"
+./bin/console queue:clean
 # TODO: poll for queue:count == 0, with timeout
 sleep 5
 
 . bin/ci-start-processes
 
 echo "Starting import"
-./bin/console queue:import all --env="$environment"
+./bin/console queue:import all
 echo "Finished launching import"
 
 . bin/ci-wait-steady-state

--- a/bin/ci-lifecycle
+++ b/bin/ci-lifecycle
@@ -4,5 +4,5 @@ set -e
 
 echo $environment
 temporary_index_name=elife_search_temporary_lifecycle_test
-./bin/console search:setup --index="$temporary_index_name" --delete --env="$environment"
-./bin/console index:delete "$temporary_index_name" --env="$environment"
+./bin/console search:setup --index="$temporary_index_name" --delete
+./bin/console index:delete "$temporary_index_name"

--- a/bin/ci-lifecycle
+++ b/bin/ci-lifecycle
@@ -2,7 +2,6 @@
 set -e
 . bin/ci-process-bootstrap
 
-echo $environment
 temporary_index_name=elife_search_temporary_lifecycle_test
 ./bin/console search:setup --index="$temporary_index_name" --delete
 ./bin/console index:delete "$temporary_index_name"

--- a/bin/ci-process-bootstrap
+++ b/bin/ci-process-bootstrap
@@ -1,10 +1,3 @@
-environment=$1
-
-if [ -z "$environment" ]; then
-    echo "environment needs to be passed as first argument";
-    exit 2;
-fi;
-
 # propagate SIGINT to waiting process
 trap 'kill -INT -$waitingPid' INT
 

--- a/bin/ci-reindex
+++ b/bin/ci-reindex
@@ -2,20 +2,20 @@
 set -e
 . bin/ci-process-bootstrap
 
-./bin/console queue:clean --env="$environment"
+./bin/console queue:clean
 # TODO: poll for queue:count == 0, with timeout
 sleep 5
 
 index_name=elife_search_$(date +%Y%m%d%H%M%S)
-./bin/console search:setup --index="$index_name" --delete --env="$environment"
+./bin/console search:setup --index="$index_name" --delete
 
-./bin/console index:switch:write "$index_name" --env="$environment"
+./bin/console index:switch:write "$index_name"
 . bin/ci-start-processes
 
 echo "Starting reindexing"
-./bin/console queue:import all --env="$environment"
+./bin/console queue:import all
 echo "Finished launching reindexing"
 
 . bin/ci-wait-steady-state
-./bin/console index:switch:read "$index_name" --env="$environment"
+./bin/console index:switch:read "$index_name"
 . bin/ci-expected-results

--- a/bin/ci-start-processes
+++ b/bin/ci-start-processes
@@ -1,8 +1,8 @@
 echo "Starting a gearman:worker"
-./bin/console gearman:worker --env="$environment" >> /tmp/gearman-worker.log 2>&1 &
+./bin/console gearman:worker >> /tmp/gearman-worker.log 2>&1 &
 workerPid=$!
 echo "gearman:worker PID $workerPid"
 echo "Starting a queue:watch"
-./bin/console queue:watch --env="$environment" >> /tmp/queue-watch.log 2>&1 &
+./bin/console queue:watch >> /tmp/queue-watch.log 2>&1 &
 queueWatchPid=$!
 echo "queue:watch PID $queueWatchPid"

--- a/bin/ci-wait-steady-state
+++ b/bin/ci-wait-steady-state
@@ -1,5 +1,5 @@
 # will return also on failing conditions such as dead processes
-timeout 60 ./bin/wait-for-empty-queues "$environment" &
+timeout 60 ./bin/wait-for-empty-queues &
 waitingPid=$!
 wait "$waitingPid"
 waitingReturnCode=$?

--- a/bin/console
+++ b/bin/console
@@ -8,14 +8,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
-// workaround: due to the lack of env variables in Upstart,
-// long-running processes have to be passed --env for now
-require_once __DIR__.'/../vendor/autoload.php';
-$input = new ArgvInput();
-$env = $input->getParameterOption(['--env', '-e']);
-putenv("ENVIRONMENT_NAME={$env}");
-// end of workaround
-
 require_once __DIR__.'/../src/bootstrap.php';
 set_time_limit(0);
 
@@ -23,6 +15,7 @@ if (!defined('GEARMAN_INSTALLED')) {
     define('GEARMAN_INSTALLED', class_exists('GearmanClient'));
 }
 $app = new Kernel($config);
+$input = new ArgvInput();
 $output = new ConsoleOutput();
 $app->get('logger')->pushHandler(new ConsoleHandler($output));
 $console = new Console(new Application('eLife Sciences Search API'), $app);

--- a/bin/reindex
+++ b/bin/reindex
@@ -15,23 +15,23 @@ sudo systemctl stop search-gearman-worker-controller.target
 sudo systemctl stop search-queue-watch-controller.target
 
 echo "Creating new index $index_name"
-./bin/console search:setup --index="$index_name" --delete --env="$environment"
+./bin/console search:setup --index="$index_name" --delete
 
 echo "Switching writes to new index $index_name"
-./bin/console index:switch:write "$index_name" --env="$environment"
+./bin/console index:switch:write "$index_name"
 
 echo "Restarting processes"
 sudo systemctl start search-gearman-worker-controller.target
 sudo systemctl start search-queue-watch-controller.target
 
 echo "Importing all API content"
-./bin/console queue:import all --env="$environment"
+./bin/console queue:import all
 
 echo "Waiting for empty queues"
 ./bin/wait-for-empty-queues "$environment"
 
 echo "Switching reads to new index $index_name"
-./bin/console index:switch:read "$index_name" --env="$environment"
+./bin/console index:switch:read "$index_name"
 # we should restart processes, but they never should use IndexMetadata::READ
 
 ./smoke_tests.sh

--- a/bin/reindex
+++ b/bin/reindex
@@ -2,13 +2,12 @@
 set -e
 
 if [ "$#" -lt 2 ]; then
-    echo "Usage: bin/reindex ENVIRONMENT INDEX_NAME"
-    echo "Example: bin/reindex end2end elife_search_67"
+    echo "Usage: bin/reindex INDEX_NAME"
+    echo "Example: bin/reindex elife_search_67"
     exit 1
 fi
 
-environment="$1"
-index_name="$2"
+index_name="$1"
 
 echo "Stopping gearman:worker instances"
 sudo systemctl stop search-gearman-worker-controller.target
@@ -28,7 +27,7 @@ echo "Importing all API content"
 ./bin/console queue:import all
 
 echo "Waiting for empty queues"
-./bin/wait-for-empty-queues "$environment"
+./bin/wait-for-empty-queues
 
 echo "Switching reads to new index $index_name"
 ./bin/console index:switch:read "$index_name"

--- a/bin/reindex-on-demand
+++ b/bin/reindex-on-demand
@@ -2,13 +2,12 @@
 set -e
 
 if [ "$#" -lt 2 ]; then
-    echo "Usage: bin/reindex-on-demand ENVIRONMENT POSSIBLE_INDEX_NAME"
-    echo "Example: bin/reindex-on-demand end2end elife_search_90"
+    echo "Usage: bin/reindex-on-demand POSSIBLE_INDEX_NAME"
+    echo "Example: bin/reindex-on-demand elife_search_90"
     exit 1
 fi
 
-environment="$1"
-possible_index_name="$2"
+possible_index_name="$1"
 
 existing_index_name=$(php bin/console index:read)
 existing_last_import=$(php bin/console index:lastimport:get)
@@ -18,7 +17,7 @@ echo "Desired last import: $desired_last_import"
 
 if [ "$existing_last_import" != "$desired_last_import" ]; then
     echo "Reindexing"
-    bin/reindex "$environment" "$possible_index_name"
+    bin/reindex "$possible_index_name"
     bin/console index:lastimport:update "$desired_last_import"
     bin/console index:delete "$existing_index_name"
 else

--- a/bin/reindex-on-demand
+++ b/bin/reindex-on-demand
@@ -10,8 +10,8 @@ fi
 environment="$1"
 possible_index_name="$2"
 
-existing_index_name=$(php bin/console index:read --env="$environment")
-existing_last_import=$(php bin/console index:lastimport:get --env="$environment")
+existing_index_name=$(php bin/console index:read)
+existing_last_import=$(php bin/console index:lastimport:get)
 desired_last_import=$(cat index.import)
 echo "Current last import: $existing_last_import"
 echo "Desired last import: $desired_last_import"
@@ -19,8 +19,8 @@ echo "Desired last import: $desired_last_import"
 if [ "$existing_last_import" != "$desired_last_import" ]; then
     echo "Reindexing"
     bin/reindex "$environment" "$possible_index_name"
-    bin/console index:lastimport:update "$desired_last_import" --env="$environment"
-    bin/console index:delete "$existing_index_name" --env="$environment"
+    bin/console index:lastimport:update "$desired_last_import"
+    bin/console index:delete "$existing_index_name"
 else
     echo "Not reindexing"
 fi

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -19,7 +19,7 @@ while true; do
         echo "No alive queue:watch processes"
         break
     fi
-    sqs_queue=$(bin/console --env="$environment" queue:count)
+    sqs_queue=$(bin/console queue:count)
     echo "Job in SQS queue (approximate): $sqs_queue"
     gearman_queue=$(gearadmin --status | cut -f 2 | paste -sd+ | bc)
     echo "Job in Gearman queue: $gearman_queue"

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 set -e
-environment=$1
-
-if [ -z "$environment" ]; then
-    echo "environment needs to be passed as first argument";
-    exit 2;
-fi;
 
 while true; do
     # `|| true` avoid failing the script when there are no results

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -1,17 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-env="${ENVIRONMENT_NAME:-ci}"
-
 rm -f build/*.xml
 proofreader src/ tests/ web/
 vendor/bin/phpunit --log-junit build/phpunit.xml
 
 echo "Creating, deleting an index"
-bin/ci-lifecycle "$env"
+bin/ci-lifecycle
 
 echo "Importing api-dummy"
-bin/ci-import "$env"
+bin/ci-import
 
 echo "Reindexing api-dummy"
-bin/ci-reindex "$env"
+bin/ci-reindex

--- a/src/Search/Console.php
+++ b/src/Search/Console.php
@@ -258,6 +258,7 @@ final class Console
         // Some annotations
         Register::registerLoader();
 
+        // TODO: remove when it is *never* passed in by the formula or anything else
         $this->console->getDefinition()->addOption(new InputOption('--env', '-e', InputOption::VALUE_OPTIONAL, 'The Environment name. Deprecated and not used', 'dev'));
 
         // Add commands from the DI container. (for more complex commands.)


### PR DESCRIPTION
Enables https://github.com/elifesciences/elife-alfred-formula/pull/33

The application doesn't need to know about the name of the environment anymore, as all options are duly passed in via `config.php`.