### PR TITLE
Updated elife/api-sdk to dff23fd: Add support for press packages in highlight lists

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -677,12 +677,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "1e14ec9267bd46b5d3ab33fc19e64dee0736564d"
+                "reference": "dff23fde2429b40a08ca548d801c39f7ae0ad2c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/1e14ec9267bd46b5d3ab33fc19e64dee0736564d",
-                "reference": "1e14ec9267bd46b5d3ab33fc19e64dee0736564d",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/dff23fde2429b40a08ca548d801c39f7ae0ad2c9",
+                "reference": "dff23fde2429b40a08ca548d801c39f7ae0ad2c9",
                 "shasum": ""
             },
             "require": {
@@ -722,7 +722,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2020-02-21T10:55:16+00:00"
+            "time": "2020-02-28T13:33:16+00:00"
         },
         {
             "name": "elife/api-validator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/140/display/redirect which resulted in this pull request.