### PR TITLE
Delete leftover search indexes

### DIFF
--- a/bin/reindex
+++ b/bin/reindex
@@ -34,3 +34,6 @@ echo "Switching reads to new index $index_name"
 # we should restart processes, but they never should use IndexMetadata::READ
 
 ./smoke_tests.sh
+
+echo "Deleting unused indexes"
+bin/console index:delete:unused

--- a/bin/reindex-on-demand
+++ b/bin/reindex-on-demand
@@ -19,7 +19,6 @@ if [ "$existing_last_import" != "$desired_last_import" ]; then
     echo "Reindexing"
     bin/reindex "$possible_index_name"
     bin/console index:lastimport:update "$desired_last_import"
-    bin/console index:delete "$existing_index_name"
 else
     echo "Not reindexing"
 fi

--- a/src/Search/Api/Elasticsearch/PlainElasticsearchClient.php
+++ b/src/Search/Api/Elasticsearch/PlainElasticsearchClient.php
@@ -24,6 +24,21 @@ class PlainElasticsearchClient
         return $this->index;
     }
 
+    public function allIndexes() : array
+    {
+        return array_map(
+            'trim',
+            explode(
+                "\n",
+                trim($this
+                    ->libraryClient
+                    ->cat()
+                    ->indices(['h' => 'index'])
+                )
+            )
+        );
+    }
+
     public function createIndex(string $indexName = null, $additionalParams = [])
     {
         $params = array_merge(


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/4608, a post mortem action.

- Add obscure `allIndexes()` implementation
- Add `index:delete:unused` console command
- Delete all unused indexes rather than last one