### PR TITLE
improved polling for the reindex process

### DIFF
--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
-# with just a single worker the polling may fail often as there is a gap between 
-# with two or more workers this becomes quite unlikely
+# with just a single worker the polling may fail often as there is a gap between accepting and completing a job.
+# with more workers this becomes less unlikely.
 no_workers_threshold=15 # how many attempts per-loop should be made to detect workers? 10 is safe, 15 is safer.
 no_workers_attempt=0 # which attempt are we on now?
 

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -1,14 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
+# with just a single worker the polling may fail often as there is a gap between 
+# with two or more workers this becomes quite unlikely
+no_workers_threshold=15 # how many attempts per-loop should be made to detect workers? 10 is safe, 15 is safer.
+no_workers_attempt=0 # which attempt are we on now?
+
 while true; do
     # `|| true` avoid failing the script when there are no results
     workers=$(pgrep -cf gearman:worker || true)
     watches=$(pgrep -cf queue:watch || true)
+
     if [ "$workers" -eq "0" ]; then
-        echo "No alive gearman:worker processes"
-        break
+        if [ "$no_workers_attempt" = "$no_workers_threshold" ]; then
+            echo "No alive gearman:worker processes"
+            break
+        fi
+        no_workers_attempt=$((no_workers_attempt+1))
+        sleep .10 # ten checks in a second
+        continue
     fi
+    no_workers_attempt=0 # we've found a worker, reset the counter
+
     if [ "$watches" -eq "0" ]; then
         echo "No alive queue:watch processes"
         break


### PR DESCRIPTION
@nlisgo , this is a change to the polling script used in the Alfred 'process-search-reindex' task. It's why the task fails but the new index is successfully created.

The change introduces an error threshold that must be crossed before a worker can be said to definitely not exist. In this case there are a maximum of fifteen checks, one check every tenth of a second. This granularity with a single worker lets us see each each job being consumed. I've not seen it go past ten checks yet so fifteen should be safe.