### PR TITLE
bumps timeout for finding available gearman workers to five seconds

### DIFF
--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -3,7 +3,10 @@ set -e
 
 # with just a single worker the polling may fail often as there is a gap between accepting and completing a job.
 # with more workers this becomes less unlikely.
-no_workers_threshold=15 # how many attempts per-loop should be made to detect workers? 10 is safe, 15 is safer.
+
+# how many attempts per-loop should be made to detect workers? 10 is safe for continuumtest, 15 is safer.
+# neither are safe for `prod` so a ridiculous 50 checks over a five second period is being added.
+no_workers_threshold=50 
 no_workers_attempt=0 # which attempt are we on now?
 
 while true; do


### PR DESCRIPTION
1.5 second timeout looking for an available worker isn't good enough for `search--prod` so I've bumped it to five seconds. 