### PR TITLE
wait-for-empty-queues, fixes

### DIFF
--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -6,8 +6,12 @@ set -e
 # more workers also means more CPU usage which means less CPU available for serving traffic.
 
 # how many attempts per-loop should be made to detect workers?
-no_workers_threshold=3000 # 3000 attempts with a .10s interval is five minutes.
-no_workers_attempt=0 # which attempt are we on now?
+num_workers_threshold=3000 # 3000 attempts with a .10s interval is five minutes.
+num_workers_attempt=0 # which attempt are we on now?
+
+# same again, but for the sqs watcher
+num_watches_threshold=50 # 50 attempts with a .10s interval is five seconds
+num_watches_attempt=0
 
 while true; do
     # `|| true` avoid failing the script when there are no results
@@ -15,20 +19,27 @@ while true; do
     watches=$(pgrep -cf queue:watch || true)
 
     if [ "$workers" -eq "0" ]; then
-        if [ "$no_workers_attempt" = "$no_workers_threshold" ]; then
+        if [ "$num_workers_attempt" = "$num_workers_threshold" ]; then
             echo "No alive gearman:worker processes"
             break
         fi
-        no_workers_attempt=$((no_workers_attempt+1))
+        num_workers_attempt=$((num_workers_attempt+1))
         sleep .10 # ten checks in a second
         continue
     fi
-    no_workers_attempt=0 # we've found a worker, reset the counter
+    num_workers_attempt=0 # we've found a worker, reset the counter
 
     if [ "$watches" -eq "0" ]; then
-        echo "No alive queue:watch processes"
-        break
+        if [ "$num_watches_attempt" = "$num_watches_threshold" ]; then
+            echo "No alive queue:watch processes"
+            break
+        fi
+        num_watches_attempt=$((num_watches_attempt+1))
+        sleep .10
+        continue
     fi
+    num_watches_attempt=0
+
     sqs_queue=$(bin/console queue:count)
     echo "Job in SQS queue (approximate): $sqs_queue"
     gearman_queue=$(gearadmin --status | cut -f 2 | paste -sd+ | bc)

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -6,11 +6,11 @@ set -e
 # more workers also means more CPU usage which means less CPU available for serving traffic.
 
 # how many attempts per-loop should be made to detect workers?
-num_workers_threshold=3000 # 3000 attempts with a .10s interval is five minutes.
+num_workers_threshold=100 # 100 attempts with a .10s interval is 10 seconds
 num_workers_attempt=0 # which attempt are we on now?
 
 # same again, but for the sqs watcher
-num_watches_threshold=50 # 50 attempts with a .10s interval is five seconds
+num_watches_threshold=100 # 100 attempts with a .10s interval is 10 seconds
 num_watches_attempt=0
 
 while true; do

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -3,7 +3,10 @@ set -e
 
 # with just a single worker the polling may fail often as there is a gap between accepting and completing a job.
 # with more workers this becomes less unlikely.
-no_workers_threshold=15 # how many attempts per-loop should be made to detect workers? 10 is safe, 15 is safer.
+
+# how many attempts per-loop should be made to detect workers? 10 is safe for continuumtest, 15 is safer.
+# neither are safe for `prod` so a ridiculous 50 checks over a five second period is being added.
+no_workers_threshold=50 
 no_workers_attempt=0 # which attempt are we on now?
 
 while true; do

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -5,8 +5,8 @@ set -e
 # with more workers this becomes less unlikely.
 
 # how many attempts per-loop should be made to detect workers? 10 is safe for continuumtest, 15 is safer.
-# neither are safe for `prod` so a ridiculous 50 checks over a five second period is being added.
-no_workers_threshold=50 
+# neither are safe for `prod` so a ridiculous 300 checks over a thirty second period is being added.
+no_workers_threshold=300
 no_workers_attempt=0 # which attempt are we on now?
 
 while true; do

--- a/bin/wait-for-empty-queues
+++ b/bin/wait-for-empty-queues
@@ -3,10 +3,10 @@ set -e
 
 # with just a single worker the polling may fail often as there is a gap between accepting and completing a job.
 # with more workers this becomes less unlikely.
+# more workers also means more CPU usage which means less CPU available for serving traffic.
 
-# how many attempts per-loop should be made to detect workers? 10 is safe for continuumtest, 15 is safer.
-# neither are safe for `prod` so a ridiculous 300 checks over a thirty second period is being added.
-no_workers_threshold=300
+# how many attempts per-loop should be made to detect workers?
+no_workers_threshold=3000 # 3000 attempts with a .10s interval is five minutes.
 no_workers_attempt=0 # which attempt are we on now?
 
 while true; do


### PR DESCRIPTION
~prod encounters a job that takes longer than almost everything else~

`prod` is doing something that causes the queue watcher to die or restart.

fyi @nlisgo 