### PR TITLE
Updated elife/api-sdk to 81fae30: Introduce blocks for googlemap and figshare

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -548,12 +548,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "02af549cf4ab00807ee122169a726e5fd34ca3b1"
+                "reference": "354aab4e9991f92da721746c343dd7a30404338c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/02af549cf4ab00807ee122169a726e5fd34ca3b1",
-                "reference": "02af549cf4ab00807ee122169a726e5fd34ca3b1",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/354aab4e9991f92da721746c343dd7a30404338c",
+                "reference": "354aab4e9991f92da721746c343dd7a30404338c",
                 "shasum": ""
             },
             "conflict": {
@@ -565,7 +565,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API specification",
-            "time": "2020-06-08T01:15:34+00:00"
+            "time": "2020-06-12T19:55:13+00:00"
         },
         {
             "name": "elife/api-client",
@@ -677,12 +677,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "55e41135e5bde24848a0162937934026f4d7b42b"
+                "reference": "81fae305fe3bb7fea86a3e52d6a2a4e7f5ecf169"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/55e41135e5bde24848a0162937934026f4d7b42b",
-                "reference": "55e41135e5bde24848a0162937934026f4d7b42b",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/81fae305fe3bb7fea86a3e52d6a2a4e7f5ecf169",
+                "reference": "81fae305fe3bb7fea86a3e52d6a2a4e7f5ecf169",
                 "shasum": ""
             },
             "require": {
@@ -722,7 +722,7 @@
                 "MIT"
             ],
             "description": "eLife Sciences API SDK",
-            "time": "2020-06-08T01:08:16+00:00"
+            "time": "2020-06-08T18:04:49+00:00"
         },
         {
             "name": "elife/api-validator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/155/display/redirect which resulted in this pull request.