### PR TITLE
Allow the content snippet to be written to elasticsearch

### DIFF
--- a/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
@@ -44,3 +44,7 @@ _default_:
       type: date
       format: strict_date_optional_time
       index: not_analyzed
+
+    snippet:
+      type: string
+      index: not_analyzed

--- a/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
+++ b/src/Search/Api/Elasticsearch/Command/resources/_default_.yaml
@@ -46,5 +46,11 @@ _default_:
       index: not_analyzed
 
     snippet:
-      type: string
-      index: not_analyzed
+      type: object
+      properties:
+        format:
+          type: string
+          index: not_analyzed
+        value:
+          type: string
+          index: not_analyzed

--- a/src/Search/Workflow/BlogArticleWorkflow.php
+++ b/src/Search/Workflow/BlogArticleWorkflow.php
@@ -88,6 +88,11 @@ final class BlogArticleWorkflow implements Workflow
         // Normalized fields.
         $blogArticleObject = json_decode($this->serialize($blogArticle));
         $blogArticleObject->body = $this->flattenBlocks($blogArticleObject->content ?? []);
+        $blogArticleObject->snippet = $this->serializer->normalize(
+            $blogArticle,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
         unset($blogArticleObject->content);
         $this->addSortDate($blogArticleObject, $blogArticle->getPublishedDate());
 

--- a/src/Search/Workflow/BlogArticleWorkflow.php
+++ b/src/Search/Workflow/BlogArticleWorkflow.php
@@ -88,11 +88,7 @@ final class BlogArticleWorkflow implements Workflow
         // Normalized fields.
         $blogArticleObject = json_decode($this->serialize($blogArticle));
         $blogArticleObject->body = $this->flattenBlocks($blogArticleObject->content ?? []);
-        $blogArticleObject->snippet = $this->serializer->normalize(
-            $blogArticle,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $blogArticleObject->snippet = $this->snippet($blogArticle);
         unset($blogArticleObject->content);
         $this->addSortDate($blogArticleObject, $blogArticle->getPublishedDate());
 

--- a/src/Search/Workflow/BlogArticleWorkflow.php
+++ b/src/Search/Workflow/BlogArticleWorkflow.php
@@ -88,8 +88,8 @@ final class BlogArticleWorkflow implements Workflow
         // Normalized fields.
         $blogArticleObject = json_decode($this->serialize($blogArticle));
         $blogArticleObject->body = $this->flattenBlocks($blogArticleObject->content ?? []);
-        $blogArticleObject->snippet = $this->snippet($blogArticle);
         unset($blogArticleObject->content);
+        $blogArticleObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($blogArticle))];
         $this->addSortDate($blogArticleObject, $blogArticle->getPublishedDate());
 
         // Return.

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -86,6 +86,11 @@ final class CollectionWorkflow implements Workflow
         $this->logger->debug('Collection<'.$collection->getId().'> Indexing '.$collection->getTitle());
         // Normalized fields.
         $collectionObject = json_decode($this->serialize($collection));
+        $collectionObject->snippet = $this->serializer->normalize(
+            $collection,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
         $this->addSortDate($collectionObject, $collection->getPublishedDate());
 
         // Return.

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -86,7 +86,7 @@ final class CollectionWorkflow implements Workflow
         $this->logger->debug('Collection<'.$collection->getId().'> Indexing '.$collection->getTitle());
         // Normalized fields.
         $collectionObject = json_decode($this->serialize($collection));
-        $collectionObject->snippet = $this->snippet($collection);
+        $collectionObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($collection))];
         $this->addSortDate($collectionObject, $collection->getPublishedDate());
 
         // Return.

--- a/src/Search/Workflow/CollectionWorkflow.php
+++ b/src/Search/Workflow/CollectionWorkflow.php
@@ -86,11 +86,7 @@ final class CollectionWorkflow implements Workflow
         $this->logger->debug('Collection<'.$collection->getId().'> Indexing '.$collection->getTitle());
         // Normalized fields.
         $collectionObject = json_decode($this->serialize($collection));
-        $collectionObject->snippet = $this->serializer->normalize(
-            $collection,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $collectionObject->snippet = $this->snippet($collection);
         $this->addSortDate($collectionObject, $collection->getPublishedDate());
 
         // Return.

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -88,8 +88,8 @@ final class InterviewWorkflow implements Workflow
         // Normalized fields.
         $interviewObject = json_decode($this->serialize($interview));
         $interviewObject->body = $this->flattenBlocks($interviewObject->content ?? []);
-        $interviewObject->snippet = $this->snippet($interview);
         unset($interviewObject->content);
+        $interviewObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($interview))];
         // Add publish date to sort on.
         $this->addSortDate($interviewObject, $interview->getPublishedDate());
 

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -88,11 +88,7 @@ final class InterviewWorkflow implements Workflow
         // Normalized fields.
         $interviewObject = json_decode($this->serialize($interview));
         $interviewObject->body = $this->flattenBlocks($interviewObject->content ?? []);
-        $interviewObject->snippet = $this->serializer->normalize(
-            $interview,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $interviewObject->snippet = $this->snippet($interview);
         unset($interviewObject->content);
         // Add publish date to sort on.
         $this->addSortDate($interviewObject, $interview->getPublishedDate());

--- a/src/Search/Workflow/InterviewWorkflow.php
+++ b/src/Search/Workflow/InterviewWorkflow.php
@@ -88,6 +88,11 @@ final class InterviewWorkflow implements Workflow
         // Normalized fields.
         $interviewObject = json_decode($this->serialize($interview));
         $interviewObject->body = $this->flattenBlocks($interviewObject->content ?? []);
+        $interviewObject->snippet = $this->serializer->normalize(
+            $interview,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
         unset($interviewObject->content);
         // Add publish date to sort on.
         $this->addSortDate($interviewObject, $interview->getPublishedDate());

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -13,20 +13,13 @@ trait JsonSerializeTransport
 
     private function checkSerializer()
     {
-        static $checked = false;
-
-        if (!$checked) {
-            if (
-                !isset($this->serializer) ||
-                null === $this->serializer ||
-                !$this->serializer instanceof Serializer
-            ) {
-                throw new LogicException('You must inject API SDK serializer for this to work (property: $serializer missing.)');
-            }
-            $checked = true;
+        if (
+            !isset($this->serializer) ||
+            null === $this->serializer ||
+            !$this->serializer instanceof Serializer
+        ) {
+            throw new LogicException('You must inject API SDK serializer for this to work (property: $serializer missing.)');
         }
-
-        return $checked;
     }
 
     public function deserialize(string $json)

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -56,11 +56,11 @@ trait JsonSerializeTransport
         }
         $key = 'snippet--'.spl_object_hash($article);
         if (!isset(self::$cache[$key])) {
-            self::$cache[$key] = json_encode($this->serializer->normalize(
+            self::$cache[$key] = $this->serializer->normalize(
                 $article,
                 null,
                 ['snippet' => true, 'type' => true]
-            ));
+            );
         }
 
         return self::$cache[$key];

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -41,24 +41,24 @@ trait JsonSerializeTransport
         return self::$cache[$key];
     }
 
-    public function serialize($article) : string
+    public function serialize($item) : string
     {
         $this->checkSerializer();
 
-        $key = spl_object_hash($article);
+        $key = spl_object_hash($item);
         if (!isset(self::$cache[$key])) {
-            self::$cache[$key] = $this->serializer->serialize($article, 'json');
+            self::$cache[$key] = $this->serializer->serialize($item, 'json');
         }
 
         return self::$cache[$key];
     }
 
-    public function snippet($article) : array
+    public function snippet($item) : array
     {
         $this->checkSerializer();
 
         return $this->serializer->normalize(
-            $article,
+            $item,
             null,
             ['snippet' => true, 'type' => true]
         );

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -45,7 +45,7 @@ trait JsonSerializeTransport
         return self::$cache[$key];
     }
 
-    public function snippet($article) : string
+    public function snippet($article) : array
     {
         if (
             !isset($this->serializer) ||

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -45,7 +45,7 @@ trait JsonSerializeTransport
         return self::$cache[$key];
     }
 
-    public function snippet($article) : array
+    public function snippet($article) : string
     {
         if (
             !isset($this->serializer) ||
@@ -56,11 +56,11 @@ trait JsonSerializeTransport
         }
         $key = 'snippet--'.spl_object_hash($article);
         if (!isset(self::$cache[$key])) {
-            self::$cache[$key] = $this->serializer->normalize(
+            self::$cache[$key] = json_encode($this->serializer->normalize(
                 $article,
                 null,
                 ['snippet' => true, 'type' => true]
-            );
+            ));
         }
 
         return self::$cache[$key];

--- a/src/Search/Workflow/JsonSerializeTransport.php
+++ b/src/Search/Workflow/JsonSerializeTransport.php
@@ -44,4 +44,25 @@ trait JsonSerializeTransport
 
         return self::$cache[$key];
     }
+
+    public function snippet($article) : array
+    {
+        if (
+            !isset($this->serializer) ||
+            null === $this->serializer ||
+            !$this->serializer instanceof Serializer
+        ) {
+            throw new LogicException('You must inject API SDK serializer for this to work (property: $serializer missing.)');
+        }
+        $key = 'snippet--'.spl_object_hash($article);
+        if (!isset(self::$cache[$key])) {
+            self::$cache[$key] = $this->serializer->normalize(
+                $article,
+                null,
+                ['snippet' => true, 'type' => true]
+            );
+        }
+
+        return self::$cache[$key];
+    }
 }

--- a/src/Search/Workflow/LabsPostWorkflow.php
+++ b/src/Search/Workflow/LabsPostWorkflow.php
@@ -88,11 +88,7 @@ final class LabsPostWorkflow implements Workflow
         // Normalized fields.
         $labsPostObject = json_decode($this->serialize($labsPost));
         $labsPostObject->body = $this->flattenBlocks($labsPostObject->content ?? []);
-        $labsPostObject->snippet = $this->serializer->normalize(
-            $labsPost,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $labsPostObject->snippet = $this->snippet($labsPost);
         unset($labsPostObject->content);
         $this->addSortDate($labsPostObject, $labsPost->getPublishedDate());
 

--- a/src/Search/Workflow/LabsPostWorkflow.php
+++ b/src/Search/Workflow/LabsPostWorkflow.php
@@ -88,8 +88,8 @@ final class LabsPostWorkflow implements Workflow
         // Normalized fields.
         $labsPostObject = json_decode($this->serialize($labsPost));
         $labsPostObject->body = $this->flattenBlocks($labsPostObject->content ?? []);
-        $labsPostObject->snippet = $this->snippet($labsPost);
         unset($labsPostObject->content);
+        $labsPostObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($labsPost))];
         $this->addSortDate($labsPostObject, $labsPost->getPublishedDate());
 
         return [

--- a/src/Search/Workflow/LabsPostWorkflow.php
+++ b/src/Search/Workflow/LabsPostWorkflow.php
@@ -88,6 +88,11 @@ final class LabsPostWorkflow implements Workflow
         // Normalized fields.
         $labsPostObject = json_decode($this->serialize($labsPost));
         $labsPostObject->body = $this->flattenBlocks($labsPostObject->content ?? []);
+        $labsPostObject->snippet = $this->serializer->normalize(
+            $labsPost,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
         unset($labsPostObject->content);
         $this->addSortDate($labsPostObject, $labsPost->getPublishedDate());
 

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -86,6 +86,11 @@ final class PodcastEpisodeWorkflow implements Workflow
 
         // Normalized fields.
         $podcastEpisodeObject = json_decode($this->serialize($podcastEpisode));
+        $podcastEpisodeObject->snippet = $this->serializer->normalize(
+            $podcastEpisode,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
         // Add sort date.
         $this->addSortDate($podcastEpisodeObject, $podcastEpisode->getPublishedDate());
 

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -86,11 +86,7 @@ final class PodcastEpisodeWorkflow implements Workflow
 
         // Normalized fields.
         $podcastEpisodeObject = json_decode($this->serialize($podcastEpisode));
-        $podcastEpisodeObject->snippet = $this->serializer->normalize(
-            $podcastEpisode,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $podcastEpisodeObject->snippet = $this->snippet($podcastEpisode);
         // Add sort date.
         $this->addSortDate($podcastEpisodeObject, $podcastEpisode->getPublishedDate());
 

--- a/src/Search/Workflow/PodcastEpisodeWorkflow.php
+++ b/src/Search/Workflow/PodcastEpisodeWorkflow.php
@@ -86,7 +86,7 @@ final class PodcastEpisodeWorkflow implements Workflow
 
         // Normalized fields.
         $podcastEpisodeObject = json_decode($this->serialize($podcastEpisode));
-        $podcastEpisodeObject->snippet = $this->snippet($podcastEpisode);
+        $podcastEpisodeObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($podcastEpisode))];
         // Add sort date.
         $this->addSortDate($podcastEpisodeObject, $podcastEpisode->getPublishedDate());
 

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -136,6 +136,11 @@ final class ResearchArticleWorkflow implements Workflow
             'format' => 'json',
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
+        $articleObject->snippet = $this->serializer->normalize(
+            $article,
+            null,
+            ['snippet' => true, 'type' => true]
+        );
 
         if (isset($this->rdsArticles[$article->getId()]['date'])) {
             $sortDate = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->rdsArticles[$article->getId()]['date']);

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -136,7 +136,7 @@ final class ResearchArticleWorkflow implements Workflow
             'format' => 'json',
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
-        $articleObject->snippet = $this->snippet($article);
+        $articleObject->snippet = ['format' => 'json', 'value' => json_encode($this->snippet($article))];
 
         if (isset($this->rdsArticles[$article->getId()]['date'])) {
             $sortDate = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->rdsArticles[$article->getId()]['date']);

--- a/src/Search/Workflow/ResearchArticleWorkflow.php
+++ b/src/Search/Workflow/ResearchArticleWorkflow.php
@@ -136,11 +136,7 @@ final class ResearchArticleWorkflow implements Workflow
             'format' => 'json',
             'value' => json_encode($articleObject->dataSets ?? '[]'),
         ];
-        $articleObject->snippet = $this->serializer->normalize(
-            $article,
-            null,
-            ['snippet' => true, 'type' => true]
-        );
+        $articleObject->snippet = $this->snippet($article);
 
         if (isset($this->rdsArticles[$article->getId()]['date'])) {
             $sortDate = DateTimeImmutable::createFromFormat(DATE_ATOM, $this->rdsArticles[$article->getId()]['date']);


### PR DESCRIPTION
Before switching to using a stored snippet rather than preparing a snippet we need to ensure that all the content currently in elasticsearch has a snippet available. We can achieve this by deploying this code and performing a reindex.

After determining that all content has a snippet we can then followup with https://github.com/elifesciences/search/pull/313