### PR TITLE
Introduce a performance test to ci

### DIFF
--- a/bin/ci-import
+++ b/bin/ci-import
@@ -18,3 +18,4 @@ echo "Finished launching import"
 
 . bin/ci-wait-steady-state
 . bin/ci-expected-results
+. bin/ci-performance

--- a/bin/ci-import
+++ b/bin/ci-import
@@ -18,4 +18,3 @@ echo "Finished launching import"
 
 . bin/ci-wait-steady-state
 . bin/ci-expected-results
-. bin/ci-performance

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,4 +1,12 @@
 #!/bin/bash
 set -e
 
-ab -n 100 -c 5 "http://search--vagrant/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default"
+bench=$(ab -n 100 -c 5 "http://search--vagrant/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
+
+echo "$bench\n"
+
+failed=$(echo "$bench" | grep "Failed requests" | grep -Eo "[0-9]+$")
+time_taken=$(echo "$bench" | grep "Time taken for tests" | grep -Eo "[0-9\.]+")
+
+echo "There were $failed failed requests"
+echo "Time taken was $time_taken seconds"

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-failed_requests_limit="0"
+failed_requests_limit="2"
 time_limit="45"
 
 bench=$(ab -n 100 -c 5 "127.0.0.1/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-bench=$(ab -n 100 -c 5 "http://search--vagrant/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
+bench=$(ab -n 100 -c 5 "localhost/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
 
-echo "$bench\n"
+echo -e "$bench\n"
 
 failed=$(echo "$bench" | grep "Failed requests" | grep -Eo "[0-9]+$")
 time_taken=$(echo "$bench" | grep "Time taken for tests" | grep -Eo "[0-9\.]+")

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,12 +1,26 @@
 #!/bin/bash
 set -e
 
+failed_requests_limit="0"
+time_limit="20"
+
 bench=$(ab -n 100 -c 5 "127.0.0.1/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
 
 echo -e "$bench\n"
 
-failed=$(echo "$bench" | grep "Failed requests" | grep -Eo "[0-9]+$")
+failed_requests=$(echo "$bench" | grep "Failed requests" | grep -Eo "[0-9]+$")
 time_taken=$(echo "$bench" | grep "Time taken for tests" | grep -Eo "[0-9\.]+")
+time_taken_int=$(echo "$time_taken" | grep -Eo "^[0-9]+")
 
-echo "There were $failed failed requests"
+echo "There were $failed_requests failed requests"
 echo "Time taken was $time_taken seconds"
+
+if [ "$failed_requests" -gt "$failed_requests_limit" ]; then
+    echo "Failed requests have exceeded $failed_requests_limit"
+    exit 2
+fi
+
+if [ "$time_taken_int" -ge "$time_limit" ]; then
+    echo "Time taken has exceeded $time_limit seconds"
+    exit 2
+fi

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+ab -n 100 -c 5 "http://search--vagrant/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default"

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-bench=$(ab -n 100 -c 5 "localhost/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
+bench=$(ab -n 100 -c 5 "127.0.0.1/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
 
 echo -e "$bench\n"
 

--- a/bin/ci-performance
+++ b/bin/ci-performance
@@ -2,7 +2,7 @@
 set -e
 
 failed_requests_limit="0"
-time_limit="20"
+time_limit="45"
 
 bench=$(ab -n 100 -c 5 "127.0.0.1/search?for=Updates%20to%20the%20zoonotic%20niche%20map%20of%20Ebola%20virus%20disease%20in%20Africa&page=1&per-page=10&sort=relevance&order=desc&use-date=default")
 

--- a/bin/ci-reindex
+++ b/bin/ci-reindex
@@ -19,3 +19,4 @@ echo "Finished launching reindexing"
 . bin/ci-wait-steady-state
 ./bin/console index:switch:read "$index_name"
 . bin/ci-expected-results
+. bin/ci-performance

--- a/bin/ci-reindex
+++ b/bin/ci-reindex
@@ -19,4 +19,3 @@ echo "Finished launching reindexing"
 . bin/ci-wait-steady-state
 ./bin/console index:switch:read "$index_name"
 . bin/ci-expected-results
-. bin/ci-performance

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -16,3 +16,6 @@ bin/ci-reindex
 
 echo "Reindexing RDS articles"
 bin/reindex-rds
+
+echo "Monitor performance"
+bin/ci-performance

--- a/project_tests.sh
+++ b/project_tests.sh
@@ -16,6 +16,3 @@ bin/ci-reindex
 
 echo "Reindexing RDS articles"
 bin/reindex-rds
-
-echo "Monitor performance"
-bin/ci-performance


### PR DESCRIPTION
Ultimately end2end might be the best place for this. The performance test in place is currently being performed in around 30 seconds and is only occasionally triggered any failed requests.

The script extracts the total time and failed requests values from the output of ApacheBench and this should allow us to set thresholds for these values and potentially fail builds if they exceed the threshold.