### PR TITLE
aliases wait-for-running-opensearch with an elasticsearch symlink.

### DIFF
--- a/bin/wait-for-running-elasticsearch
+++ b/bin/wait-for-running-elasticsearch
@@ -1,0 +1,1 @@
+wait-for-running-opensearch


### PR DESCRIPTION
renaming the file caused an issue in the clean-end2end env