### PR TITLE
composer, shifts elife/api out of 'require-dev'.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "clue/block-react": "^1.1",
         "doctrine/cache": "^1.6",
         "elasticsearch/elasticsearch": "^7.11",
+        "elife/api": "^2.10.0",
         "elife/api-client": "dev-master",
         "elife/api-problem": "^1.1",
         "elife/api-sdk": "dev-master",
@@ -41,7 +42,6 @@
     },
     "require-dev": {
         "csa/guzzle-cache-middleware": "^1.0",
-        "elife/api": "^2.10.0",
         "mockery/mockery": "^0.9.5",
         "phpunit/phpunit": "^5.5",
         "squizlabs/php_codesniffer": "^3.5",


### PR DESCRIPTION
it's not installed in prod and is causing a highstate failure.