### PR TITLE
Updated elife/api-sdk to 7568b9a: Allow reviewed preprints to be purged from the elastic search index

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -796,16 +796,16 @@
         },
         {
             "name": "elife/api",
-            "version": "2.10.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "6ae5549c3f45c2481ee21908182955b3e4110715"
+                "reference": "258746a05d97f2598149adf5e17af10f2560b432"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/6ae5549c3f45c2481ee21908182955b3e4110715",
-                "reference": "6ae5549c3f45c2481ee21908182955b3e4110715",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/258746a05d97f2598149adf5e17af10f2560b432",
+                "reference": "258746a05d97f2598149adf5e17af10f2560b432",
                 "shasum": ""
             },
             "conflict": {
@@ -819,9 +819,9 @@
             "description": "eLife Sciences API specification",
             "support": {
                 "issues": "https://github.com/elifesciences/api-raml/issues",
-                "source": "https://github.com/elifesciences/api-raml/tree/2.10.0"
+                "source": "https://github.com/elifesciences/api-raml/tree/2.11.0"
             },
-            "time": "2022-10-14T19:22:57+00:00"
+            "time": "2022-11-01T12:51:22+00:00"
         },
         {
             "name": "elife/api-client",
@@ -943,12 +943,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "7341f666727cbb0289ca524ed0e337aebbd44209"
+                "reference": "5b666c510ae72db5e460766c3dc7f937436c2b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/7341f666727cbb0289ca524ed0e337aebbd44209",
-                "reference": "7341f666727cbb0289ca524ed0e337aebbd44209",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/5b666c510ae72db5e460766c3dc7f937436c2b06",
+                "reference": "5b666c510ae72db5e460766c3dc7f937436c2b06",
                 "shasum": ""
             },
             "require": {
@@ -963,7 +963,7 @@
             },
             "require-dev": {
                 "csa/guzzle-cache-middleware": "^1.0",
-                "elife/api": "^2.9",
+                "elife/api": "^2.11.0",
                 "elife/api-validator": "^1.0@dev",
                 "guzzlehttp/guzzle": "^6.0",
                 "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
@@ -994,7 +994,7 @@
                 "issues": "https://github.com/elifesciences/api-sdk-php/issues",
                 "source": "https://github.com/elifesciences/api-sdk-php/tree/master"
             },
-            "time": "2022-10-14T20:19:52+00:00"
+            "time": "2022-11-01T17:10:36+00:00"
         },
         {
             "name": "elife/api-validator",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/280/display/redirect which resulted in this pull request.