### PR TITLE
Updated elife/api-sdk to 7568b9a: Allow reviewed preprints to be purged from the elastic search index

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -796,16 +796,16 @@
         },
         {
             "name": "elife/api",
-            "version": "2.10.0",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-raml.git",
-                "reference": "6ae5549c3f45c2481ee21908182955b3e4110715"
+                "reference": "3a6bb608d5cacb9f803d52b82ab44139b2d7ca8a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/6ae5549c3f45c2481ee21908182955b3e4110715",
-                "reference": "6ae5549c3f45c2481ee21908182955b3e4110715",
+                "url": "https://api.github.com/repos/elifesciences/api-raml/zipball/3a6bb608d5cacb9f803d52b82ab44139b2d7ca8a",
+                "reference": "3a6bb608d5cacb9f803d52b82ab44139b2d7ca8a",
                 "shasum": ""
             },
             "conflict": {
@@ -819,9 +819,9 @@
             "description": "eLife Sciences API specification",
             "support": {
                 "issues": "https://github.com/elifesciences/api-raml/issues",
-                "source": "https://github.com/elifesciences/api-raml/tree/2.10.0"
+                "source": "https://github.com/elifesciences/api-raml/tree/2.12.0"
             },
-            "time": "2022-10-14T19:22:57+00:00"
+            "time": "2022-11-08T09:31:37+00:00"
         },
         {
             "name": "elife/api-client",
@@ -943,12 +943,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/elifesciences/api-sdk-php.git",
-                "reference": "7341f666727cbb0289ca524ed0e337aebbd44209"
+                "reference": "5b666c510ae72db5e460766c3dc7f937436c2b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/7341f666727cbb0289ca524ed0e337aebbd44209",
-                "reference": "7341f666727cbb0289ca524ed0e337aebbd44209",
+                "url": "https://api.github.com/repos/elifesciences/api-sdk-php/zipball/5b666c510ae72db5e460766c3dc7f937436c2b06",
+                "reference": "5b666c510ae72db5e460766c3dc7f937436c2b06",
                 "shasum": ""
             },
             "require": {
@@ -963,7 +963,7 @@
             },
             "require-dev": {
                 "csa/guzzle-cache-middleware": "^1.0",
-                "elife/api": "^2.9",
+                "elife/api": "^2.11.0",
                 "elife/api-validator": "^1.0@dev",
                 "guzzlehttp/guzzle": "^6.0",
                 "justinrainbow/json-schema": "^3.0 || ^4.0 || ^5.0",
@@ -994,7 +994,7 @@
                 "issues": "https://github.com/elifesciences/api-sdk-php/issues",
                 "source": "https://github.com/elifesciences/api-sdk-php/tree/master"
             },
-            "time": "2022-10-14T20:19:52+00:00"
+            "time": "2022-11-01T17:10:36+00:00"
         },
         {
             "name": "elife/api-validator",
@@ -3802,16 +3802,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.26.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4"
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
-                "reference": "6fd1b9a79f6e3cf65f9e679b23af304cd9e010d4",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/5bbc823adecdae860bb64756d639ecfec17b050a",
+                "reference": "5bbc823adecdae860bb64756d639ecfec17b050a",
                 "shasum": ""
             },
             "require": {
@@ -3826,7 +3826,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.26-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -3864,7 +3864,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.26.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -3880,7 +3880,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-05-24T11:49:31+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",


### PR DESCRIPTION
I have run https://alfred.elifesciences.org/job/dependencies/job/dependencies-search-update-api-sdk-php/281/display/redirect which resulted in this pull request.